### PR TITLE
Term_def gives the expr id given to the defined symbol

### DIFF
--- a/src/loop/pipes.ml
+++ b/src/loop/pipes.ml
@@ -32,7 +32,7 @@ module Make
 
   type defs = [
     | `Type_def of Dolmen.Id.t * Expr.ty_var list * Expr.ty
-    | `Term_def of Dolmen.Id.t * Expr.ty_var list * Expr.term_var list * Expr.term
+    | `Term_def of Dolmen.Id.t * Expr.term_const * Expr.ty_var list * Expr.term_var list * Expr.term
   ]
 
   type decl = [

--- a/src/loop/pipes.mli
+++ b/src/loop/pipes.mli
@@ -42,9 +42,9 @@ module Make
 
   type defs = [
     | `Type_def of Dolmen.Id.t * Expr.ty_var list * Expr.ty
-    | `Term_def of Dolmen.Id.t * Expr.ty_var list * Expr.term_var list * Expr.term
+    | `Term_def of Dolmen.Id.t * Expr.term_const * Expr.ty_var list * Expr.term_var list * Expr.term
   ]
-  (** The type of top-level type definitions. *)
+  (** The type of top-level type definitions. Type definitions are inlined and so can be ignored. *)
 
   type assume = [
     | `Hyp of Expr.formula

--- a/src/loop/typer.ml
+++ b/src/loop/typer.ml
@@ -388,11 +388,11 @@ module Make(S : State_intf.Typer) = struct
     let env = typing_env ?loc:t.loc st in
     begin match T.new_def ?attr env t id with
       | `Type_def (id, _, vars, body) ->
-        let _ = Subst.define_ty id vars body in
+        let () = Subst.define_ty id vars body in
         st, `Type_def (id, vars, body), get_warnings ()
       | `Term_def (id, _, vars, args, body) ->
-        let _ = Decl.define_term id vars args body in
-        st, `Term_def (id, vars, args, body), get_warnings ()
+        let expr_id = Decl.define_term id vars args body in
+        st, `Term_def (id, expr_id, vars, args, body), get_warnings ()
     end
 
   let decls st ?attr l =

--- a/src/loop/typer_intf.ml
+++ b/src/loop/typer_intf.ml
@@ -33,7 +33,7 @@ module type S = sig
     state *
     [
      | `Type_def of Dolmen.Id.t * ty_var list * ty
-     | `Term_def of Dolmen.Id.t * ty_var list * term_var list * term
+     | `Term_def of Dolmen.Id.t * term_const * ty_var list * term_var list * term
     ] *
     (Dolmen.ParseLocation.t * string) list
 


### PR DESCRIPTION
Types definition are substituted but Term definition are not so we need the `Expr.term_const` associated.