### PR TITLE
Implement UF/DT theory restrictions

### DIFF
--- a/dune
+++ b/dune
@@ -1,0 +1,3 @@
+; Ensure no inlinging takes place in dev mode to have more accurate backtraces
+(env (dev (ocamlopt_flags -g -inline 0)))
+

--- a/src/loop/state_intf.ml
+++ b/src/loop/state_intf.ml
@@ -13,7 +13,7 @@ type source = [
   | `Raw of string * string
 ]
 
-type phase =[
+type phase = [
   | `Parsing
   | `Include
   | `Typing

--- a/src/loop/typer.mli
+++ b/src/loop/typer.mli
@@ -3,6 +3,8 @@
 
 module type S = sig
 
+  (** {2 Main interface} *)
+
   type solve_st
 
   module T : Dolmen_type.Tff_intf.S
@@ -27,6 +29,20 @@ module type S = sig
 
   val report_error : Format.formatter -> T.err -> unit
   (** Report a typing error on the given formatter. *)
+
+
+  (** {2 Error reporting helpers} *)
+
+  val binding_loc :
+    (_, _, _, _) Dolmen_type.Tff.binding ->
+    Dolmen.ParseLocation.t
+
+  val print_shadowing_reasons :
+    Format.formatter ->
+    Dolmen.Id.t *
+    (_, _, _, _) Dolmen_type.Tff.binding *
+    (_, _, _, _) Dolmen_type.Tff.binding -> unit
+  (** Print reasons for a shadowing *)
 
 end
 

--- a/src/lsp/loop.ml
+++ b/src/lsp/loop.ml
@@ -27,11 +27,15 @@ let handle_exn st = function
     Ok (State.error st loc "Lexing error: %s" msg)
   (* Parsing error *)
   | Dolmen.ParseLocation.Syntax_error (loc, msg) ->
-    Ok (State.error st loc "Syntax error %s" msg)
+    Ok (State.error st loc "Syntax error: %s" msg)
   (* Typing error *)
   | State.Typer.T.Typing_error (err, _, t) ->
     let loc = get_loc t.Dolmen.Term.loc in
     Ok (State.error st loc "Typing error: %a" State.Typer.report_error err)
+  | State.Typer.T.Shadowing (id, old, cur) ->
+    let loc = State.Typer.binding_loc cur in
+    Ok (State.error st loc "Typing error: %a"
+          State.Typer.print_shadowing_reasons (id, old, cur))
 
   (* File not found *)
   | State.File_not_found (l, dir, f) ->

--- a/src/lsp/state.ml
+++ b/src/lsp/state.ml
@@ -48,8 +48,6 @@ let warn t loc msg =
   add_diag d t
 
 let error t loc format =
-  (* NOTE: probably useless, kasprintf allocates a new buffer… right? *)
-  Format.pp_set_margin Format.str_formatter 500;
   Format.kasprintf (fun msg ->
       let d = Diagnostic.error ~loc msg in
       add_diag d t

--- a/src/typecheck/base.ml
+++ b/src/typecheck/base.ml
@@ -27,55 +27,90 @@ type smtlib_theory = [
   | `Reals_Ints
 ]
 
-type smtlib_restriction = [
-  | `No_free_symbol
-  | `Quantifier_free
-  | `Difference_logic
-  | `Linear_arithmetic
-]
+type smtlib_features = {
+  uninterpreted   : bool;
+  datatypes       : bool;
+  quantifiers     : bool;
+  arithmetic      : [ `Linear | `Difference | `Regular ];
+}
 
 type smtlib_logic = {
   theories      : smtlib_theory list;
-  restrictions  : smtlib_restriction list;
+  features      : smtlib_features;
 }
 
 (*
-QF for the restriction to quantifier free formulas
+QF to disable the quantifier feature
 A or AX for the theory ArraysEx
 BV for the theory FixedSizeBitVectors
 FP (forthcoming) for the theory FloatingPoint
 IA for the theory Ints (Integer Arithmetic)
 RA for the theory Reals (Real Arithmetic)
 IRA for the theory Reals_Ints (mixed Integer Real Arithmetic)
-IDL for Integer Difference Logic
-RDL for Rational Difference Logic
+IDL for Integer Difference Logic (Ints theory + difference logic arithmetic)
+RDL for Reals Difference Logic (Reals theory + difference logic arithmetic)
 L before IA, RA, or IRA for the linear fragment of those arithmetics
 N before IA, RA, or IRA for the non-linear fragment of those arithmetics
 UF for the extension allowing free sort and function symbols
 *)
-
 let smtlib_logic s =
-  let add_restrictions c r = { c with restrictions = r::c.restrictions } in
-  let add_theories c r = { c with theories = r::c.theories } in
-  let rec aux c = function
+  let default = {
+    theories = [ `Core ];
+    features = {
+      uninterpreted = false;
+      datatypes = false;
+      quantifiers = true;
+      arithmetic = `Regular;
+    };
+  } in
+  let add_theory t c = { c with theories = t :: c.theories } in
+  let set_features c f = { c with features = f c.features } in
+  let set_uf c = set_features c (fun f -> { f with uninterpreted = true}) in
+  let set_qf c = set_features c (fun f -> { f with quantifiers = false}) in
+  let set_dt c = set_features c (fun f -> { f with datatypes = true}) in
+  let set_dl c = set_features c (fun f -> { f with arithmetic = `Difference}) in
+  let set_la c = set_features c (fun f -> { f with arithmetic = `Linear}) in
+  (* The QF theory can only appear as a prefix "QF_" *)
+  let rec parse1 c = function
     | [] -> Some c
-    | 'Q'::'F'::'_'::l -> aux (add_restrictions c `Quantifier_free) l
-    | 'U'::'F'::l -> aux c l
-    | 'D'::'T'::l -> aux c l
-    | 'I'::'D'::'L'::l ->  aux (add_theories (add_restrictions c `Difference_logic) `Ints) l
-    | 'R'::'D'::'L'::l ->  aux (add_theories (add_restrictions c `Difference_logic) `Reals) l
-    | 'L'::'I'::'A'::l -> aux (add_theories (add_restrictions c `Linear_arithmetic) `Ints) l
-    | 'L'::'R'::'A'::l -> aux (add_theories (add_restrictions c `Linear_arithmetic) `Reals) l
-    | 'L'::'I'::'R'::'A'::l -> aux (add_theories (add_restrictions c `Linear_arithmetic) `Reals_Ints) l
-    | 'N'::'I'::'A'::l -> aux (add_theories c `Ints) l
-    | 'N'::'R'::'A'::l -> aux (add_theories c `Reals) l
-    | 'N'::'I'::'R'::'A'::l -> aux (add_theories c `Reals_Ints) l
-    | 'A'::'X'::l | 'A'::l  -> aux (add_theories c `Arrays) l
-    | 'B'::'V'::l -> aux (add_theories c `Bitvectors) l
+    | 'Q'::'F'::'_'::l -> parse2 (set_qf c) l
+    | l -> parse2 c l
+  (* The Array theory is specified first after an optional QF_, and
+     can be one of two forms:
+     - either 'A' followed by some other theories
+     - either 'AX' followed by no theory *)
+  and parse2 c = function
+    | 'A'::'X'::l -> parse6 (add_theory `Arrays c) l
+    | 'A'::[] -> None (* "QF_A" and "A" are not valid logics *)
+    | 'A'::l  -> parse3 (add_theory `Arrays c) l
+    | l -> parse3 c l
+  (* The UF theory can be specified after the array theory *)
+  and parse3 c = function
+    | 'U'::'F'::l -> parse4 (set_uf c) l
+    | l -> parse4 c l
+  (* After the QF, Array and UF theories have been specified,
+     one of the BV or some arithmetic theory can be specified. *)
+  and parse4 c = function
+    | 'B'::'V'::l -> parse5 (add_theory `Bitvectors c) l
+    | 'I'::'D'::'L'::l -> parse5 (add_theory `Ints (set_dl c)) l
+    | 'R'::'D'::'L'::l -> parse5 (add_theory `Reals (set_dl c)) l
+    | 'L'::'I'::'A'::l -> parse5 (add_theory `Ints (set_la c)) l
+    | 'L'::'R'::'A'::l -> parse5 (add_theory `Reals (set_la c)) l
+    | 'L'::'I'::'R'::'A'::l -> parse5 (add_theory `Reals_Ints (set_la c)) l
+    | 'N'::'I'::'A'::l -> parse5 (add_theory `Ints c) l
+    | 'N'::'R'::'A'::l -> parse5 (add_theory `Reals c) l
+    | 'N'::'I'::'R'::'A'::l -> parse5 (add_theory `Reals_Ints c) l
+    | l -> parse5 c l
+  (* TODO: where can the DT theory appear ? *)
+  and parse5 c = function
+    | 'D'::'T'::l -> parse6 (set_dt c) l
+    | l -> parse6 c l
+  (* End of list *)
+  and parse6 c = function
+    | [] -> Some c
     | _ -> None
   in
-  aux { theories = [ `Core ]; restrictions = [] } (List.of_seq (String.to_seq s))
-
+  parse1 default (List.of_seq (String.to_seq s))
 
 (* Building builtins parser functions *)
 (* ************************************************************************ *)

--- a/src/typecheck/base.mli
+++ b/src/typecheck/base.mli
@@ -78,17 +78,17 @@ type smtlib_theory = [
 ]
 (** Smtlib theories. *)
 
-type smtlib_restriction = [
-  | `No_free_symbol
-  | `Quantifier_free
-  | `Difference_logic
-  | `Linear_arithmetic
-]
-(** Smtlib restrictions. *)
+type smtlib_features = {
+  uninterpreted   : bool;
+  datatypes       : bool;
+  quantifiers     : bool;
+  arithmetic      : [ `Linear | `Difference | `Regular ];
+}
+(** Smtlib features. *)
 
 type smtlib_logic = {
   theories      : smtlib_theory list;
-  restrictions  : smtlib_restriction list;
+  features      : smtlib_features;
 }
 (** Structured representation of an smtlib logic. *)
 

--- a/src/typecheck/tff.ml
+++ b/src/typecheck/tff.ml
@@ -265,9 +265,14 @@ module Make
 
     (* Additional typing info *)
     expect       : expect;
-    allow_shadow : bool;
     infer_base   : Ty.t option;
     infer_hook   : env -> inferred -> unit;
+
+    (* Potential restrictions on the typing *)
+    allow_shadow              : bool;
+    allow_function_decl       : bool;
+    allow_data_type_decl      : bool;
+    allow_abstract_type_decl  : bool;
   }
 
   (* Builtin symbols, i.e symbols understood by some theories,
@@ -321,6 +326,10 @@ module Make
 
   (* Exception for not well-dounded datatypes definitions. *)
   exception Not_well_founded_datatypes of Dolmen.Statement.decl list
+
+  (* Exception for declarations forbidden by the env
+     (i.e. by the user's settings). *)
+  exception Illegal_declaration of env * Dolmen.Statement.decl
 
     (* TOOD: uncomment this code
   (* Creating explanations *)
@@ -482,17 +491,19 @@ module Make
 
   (* Make a new empty environment *)
   let empty_env
-      ?(st=global)
-      ?(expect=Nothing)
-      ?(allow_shadow=true)
-      ?(infer_hook=(fun _ _ -> ()))
-      ?infer_base
+      ?(st=global) ?(expect=Nothing)
+      ?(infer_hook=(fun _ _ -> ())) ?infer_base
+      ?(allow_shadow=true) ?(allow_function_decl=true)
+      ?(allow_data_type_decl=true) ?(allow_abstract_type_decl=true)
       builtins = {
     type_locs = E.empty;
     term_locs = F.empty;
     type_vars = M.empty;
     term_vars = M.empty;
-    st; builtins; expect; allow_shadow; infer_hook; infer_base;
+    st; builtins; expect;
+    infer_hook; infer_base;
+    allow_shadow; allow_function_decl;
+    allow_data_type_decl; allow_abstract_type_decl;
   }
 
   let expect ?(force=false) env expect =
@@ -1283,11 +1294,16 @@ module Make
         | Abstract { id; ty; loc; } ->
           begin match parse_sig env ty with
             | `Ty_cstr n ->
+              if not env.allow_abstract_type_decl then
+                raise (Illegal_declaration (env, t));
               let c = Ty.Const.mk (Id.full_name id) n in
               List.iter (fun (Any (tag, v)) -> Ty.Const.tag c tag v) tags;
               decl_ty_const env id c (Declared (or_default_loc loc));
               `Type_decl c
             | `Fun_ty (vars, args, ret) ->
+              if not env.allow_function_decl &&
+                 (vars <> [] || args <> []) then
+                raise (Illegal_declaration (env, t));
               let f = T.Const.mk (Id.full_name id) vars args ret in
               List.iter (fun (Any (tag, v)) -> T.Const.tag f tag v) tags;
               decl_term_const env id f (Declared (or_default_loc loc));
@@ -1295,6 +1311,8 @@ module Make
           end
         | Record { id; vars; loc; _ }
         | Inductive { id; vars; loc; _ } ->
+          if not env.allow_data_type_decl then
+            raise (Illegal_declaration (env, t));
           let n = List.length vars in
           let c = Ty.Const.mk (Id.full_name id) n in
           List.iter (fun (Any (tag, v)) -> Ty.Const.tag c tag v) tags;

--- a/src/typecheck/tff.ml
+++ b/src/typecheck/tff.ml
@@ -321,6 +321,7 @@ module Make
 
   (** Exception for redefinition/shadowing *)
   exception Shadowing of
+      Dolmen.Id.t *
       (Ty.Const.t, T.Cstr.t, T.Field.t, T.Const.t) binding *
       (Ty.Const.t, T.Cstr.t, T.Field.t, T.Const.t) binding
 
@@ -455,7 +456,7 @@ module Make
         if env.allow_shadow then
           W.shadow id old_binding new_binding
         else
-          raise (Shadowing (old_binding, new_binding))
+          raise (Shadowing (id, old_binding, new_binding))
     end;
     H.add env.st.csts id v
 

--- a/src/typecheck/tff_intf.ml
+++ b/src/typecheck/tff_intf.ml
@@ -110,6 +110,10 @@ module type S = sig
   (** Exception raised when a list of inductive datatypes could not be proved to
       be well-founded. *)
 
+  exception Illegal_declaration of env * Dolmen.Statement.decl
+  (** Exception raised when type-checking a list of declarations and some
+      of the declarations are not allowed by the environment. *)
+
   type 'a typer = env -> Dolmen.Term.t -> 'a
   (** A general type for typers. Takes a local environment and the current untyped term,
       and return a value. The typer may need additional information for parsing,
@@ -136,9 +140,12 @@ module type S = sig
   val empty_env :
     ?st:state ->
     ?expect:expect ->
-    ?allow_shadow:bool ->
     ?infer_hook:(env -> inferred -> unit) ->
     ?infer_base:Ty.t ->
+    ?allow_shadow:bool ->
+    ?allow_function_decl:bool ->
+    ?allow_data_type_decl:bool ->
+    ?allow_abstract_type_decl:bool ->
     builtin_symbols -> env
   (** Create a new environment. *)
 

--- a/src/typecheck/tff_intf.ml
+++ b/src/typecheck/tff_intf.ml
@@ -101,6 +101,7 @@ module type S = sig
   (** Exception raised when a typing error is encountered. *)
 
   exception Shadowing of
+      Dolmen.Id.t *
       (Ty.Const.t, T.Cstr.t, T.Field.t, T.Const.t) binding *
       (Ty.Const.t, T.Cstr.t, T.Field.t, T.Const.t) binding
   (** Exception raised upon redefinition of symbols/constants

--- a/tests/regression/pr36/dune
+++ b/tests/regression/pr36/dune
@@ -1,0 +1,22 @@
+
+(rule
+  (target  shadow.output)
+  (deps    shadow.smt2)
+  (package dolmen_bin)
+  (action (chdir %{workspace_root} (with-outputs-to %{target} (with-accepted-exit-codes 1 (run dolmen  %{deps})))))
+)
+(rule
+  (alias runtest)
+  (action (diff shadow.expected shadow.output))
+)
+
+(rule
+  (target  illegal_decl.output)
+  (deps    illegal_decl.smt2)
+  (package dolmen_bin)
+  (action (chdir %{workspace_root} (with-outputs-to %{target} (with-accepted-exit-codes 1 (run dolmen  %{deps})))))
+)
+(rule
+  (alias runtest)
+  (action (diff illegal_decl.expected illegal_decl.output))
+)

--- a/tests/regression/pr36/illegal_decl.expected
+++ b/tests/regression/pr36/illegal_decl.expected
@@ -1,0 +1,2 @@
+[91mError[0m Unhandled exception:
+      Dolmen_type.Tff.Make(Tag)(Ty)(T)(W).Illegal_declaration(_, _)

--- a/tests/regression/pr36/illegal_decl.smt2
+++ b/tests/regression/pr36/illegal_decl.smt2
@@ -1,0 +1,4 @@
+(set-logic QF_AX)
+(declare-fun f (Bool) Bool)
+(check-sat)
+(exit)

--- a/tests/regression/pr36/shadow.expected
+++ b/tests/regression/pr36/shadow.expected
@@ -1,0 +1,2 @@
+[91mError[0m Unhandled exception:
+      Dolmen_type.Tff.Make(Tag)(Ty)(T)(W).Shadowing(_, _, _)

--- a/tests/regression/pr36/shadow.smt2
+++ b/tests/regression/pr36/shadow.smt2
@@ -1,0 +1,5 @@
+(set-logic QF_UF)
+(declare-fun f () Bool)
+(declare-fun f () Bool)
+(check-sat)
+(exit)

--- a/tests/typing/errors/wrong-type/dune
+++ b/tests/typing/errors/wrong-type/dune
@@ -9,7 +9,7 @@
 )
 (rule
   (alias runtest)
-  (action (diff test_tptp_infer.output test_tptp_infer.expected))
+  (action (diff test_tptp_infer.expected test_tptp_infer.output))
 )
 
 ; Test for test_tptp.p
@@ -21,7 +21,7 @@
 )
 (rule
   (alias runtest)
-  (action (diff test_tptp.output test_tptp.expected))
+  (action (diff test_tptp.expected test_tptp.output))
 )
 
 ; Test for test_smtlib.smt2
@@ -33,6 +33,6 @@
 )
 (rule
   (alias runtest)
-  (action (diff test_smtlib.output test_smtlib.expected))
+  (action (diff test_smtlib.expected test_smtlib.output))
 )
 

--- a/tests/typing/errors/wrong-type/test_smtlib.smt2
+++ b/tests/typing/errors/wrong-type/test_smtlib.smt2
@@ -1,4 +1,4 @@
-(set-logic LIA)
+(set-logic UFLIA)
 (declare-sort foo 0)
 (declare-fun a () foo)
 (declare-fun p (Int) Bool)

--- a/tests/typing/valid/smtlib/v2.6/fun_def/test-fun_def_1.smt2
+++ b/tests/typing/valid/smtlib/v2.6/fun_def/test-fun_def_1.smt2
@@ -1,4 +1,4 @@
-(set-logic QF_UF)
+(set-logic QF_UFDT)
 (declare-datatype Threevalue ((TVTRUE) (TVFALSE) (TVUNKNOWN)))
 (define-fun tvnot ((phi Threevalue)) Threevalue
 	(ite (= phi TVTRUE) TVFALSE (ite (= phi TVFALSE) TVTRUE TVUNKNOWN) )

--- a/tests/typing/valid/smtlib/v2.6/fun_def/test-fun_def_2.smt2
+++ b/tests/typing/valid/smtlib/v2.6/fun_def/test-fun_def_2.smt2
@@ -1,4 +1,4 @@
-(set-logic QF_UF)
+(set-logic QF_UFDT)
 (declare-datatype Threevalue ((TVTRUE) (TVFALSE) (TVUNKNOWN) ))
 (define-fun tvor ((phi1 Threevalue) (phi2 Threevalue)) Threevalue
 	(ite (or (= phi1 TVTRUE) (= phi2 TVTRUE) ) TVTRUE (ite (and (= phi1 TVFALSE) (= phi2 TVFALSE)) TVFALSE TVUNKNOWN ) )


### PR DESCRIPTION
This is still WIP, but contains quite a few changes:
- the typechecker and typing loop are adapted to reject declarations that do not respect the restrictions imposed by the (lack of) UF/DT theories
- some additions to error reporting which is missing a few cases (still in progress)
- the representation of smtlib logic is a bit more structured now, restrictions are transformed into a set of features represented as field of a record
- the parsing of smtlib logic is made a bit more strict by taking into account:
  - the order in which theories can appear in a logic name
  - the fact the a theory can not be repeated in a logic name

This last point probably some review/comment by @bobot , who should be more knowledgeable about whether it is correct/reasonable; the idea was to not allow to parse logic such as `LIABVQF_ANIRA`, which the current code happily parses, even though it's not really a valid theory declaration (it's incoherent with respect to arithmetic for instance).