### PR TITLE
Fixes from COLIBRI

### DIFF
--- a/src/loop/typer.ml
+++ b/src/loop/typer.ml
@@ -690,18 +690,6 @@ module Make(S : State_intf.Typer) = struct
   (* Setting the logic *)
   (* ************************************************************************ *)
 
-  let default_smtlib2_logic = {
-    Dolmen_type.Logic.Smtlib2.theories =
-      [ `Core; `Reals_Ints; `Arrays; `Bitvectors; ];
-    features = {
-      free_sorts = true;
-      free_functions = true;
-      datatypes = true;
-      quantifiers = true;
-      arithmetic = `Regular;
-    };
-  }
-
   let set_logic (st : _ Dolmen.State.state) ?(loc=no_loc) s =
     (* auxiliary funciton/lens to set the logic in the state *)
     let set (st : _ Dolmen.State.state) logic = {
@@ -717,7 +705,7 @@ module Make(S : State_intf.Typer) = struct
         | Some l -> l
         | None ->
           add_raw_warning loc (Format.asprintf "Unknown logic %s" s);
-          default_smtlib2_logic
+          Dolmen_type.Logic.Smtlib2.all
       in
       set st (Smtlib2 l), get_warnings ()
     | _ ->

--- a/src/loop/typer.mli
+++ b/src/loop/typer.mli
@@ -42,6 +42,12 @@ module type S = sig
   (** Return a reporter for the given warning, if the warning should be
       reported. *)
 
+  val additional_builtins : T.builtin_symbols ref
+  (** This reference can be modified to parse new builtin symbols. By default no
+      additional builtin symbols are parsed. It is added for all the languages
+      except Dimacs, and iCNF.
+  *)
+
 end
 
 module Make(S : State_intf.Typer) : S with type solve_st := S.solve_st

--- a/src/standard/expr.ml
+++ b/src/standard/expr.ml
@@ -2310,7 +2310,7 @@ module Term = struct
       let fp =
         with_cache ~cache:(Hashtbl.create 13) (fun (e, s) ->
             Id.const ~builtin:(Fp(e, s)) "fp" []
-              [Ty.bitv 1; Ty.bitv e; Ty.bitv s] (Ty.float e (s + 1))
+              [Ty.bitv 1; Ty.bitv e; Ty.bitv (s-1)] (Ty.float e s)
           )
 
       let roundNearestTiesToEven =
@@ -2960,7 +2960,7 @@ module Term = struct
     let fp sign exp significand =
       let e = Bitv.match_bitv_type exp in
       let s = Bitv.match_bitv_type significand in
-      apply (Const.Float.fp (e, s)) [] [sign; exp; significand]
+      apply (Const.Float.fp (e, s+1)) [] [sign; exp; significand]
 
     let roundNearestTiesToEven = apply Const.Float.roundNearestTiesToEven [] []
     let roundNearestTiesToAway = apply Const.Float.roundNearestTiesToAway [] []

--- a/src/standard/expr.ml
+++ b/src/standard/expr.ml
@@ -557,11 +557,11 @@ module Filter = struct
     | `Warn
     | `Error of string
   ]
-  type ty_filter = ty_const -> ty list -> status
-  type term_filter = term_const -> ty list -> term list -> status
+  type ty_filter = string * bool ref * (ty_const -> ty list -> status)
+  type term_filter = string * bool ref * (term_const -> ty list -> term list -> status)
 
-  let ty : (string * bool ref * ty_filter) tag = Tag.create ()
-  let term : (string * bool ref * term_filter) tag = Tag.create ()
+  let ty : ty_filter tag = Tag.create ()
+  let term : term_filter tag = Tag.create ()
 
   module type S = sig
     val name : string
@@ -1095,6 +1095,8 @@ module Id = struct
   let compare v v' = compare v.index v'.index
 
   let equal v v' = compare v v' = 0
+
+  let print fmt id = Format.pp_print_string fmt id.name
 
   (* Tags *)
   let tag (id : _ id) k v = id.tags <- Tag.add id.tags k v

--- a/src/standard/expr.ml
+++ b/src/standard/expr.ml
@@ -2123,7 +2123,7 @@ module Term = struct
 
       let extract =
         with_cache ~cache:(Hashtbl.create 13) (fun (i, j, n) ->
-            Id.const ~builtin:(Bitv_extract (j, i))
+            Id.const ~builtin:(Bitv_extract (i, j))
               (Format.asprintf "bitv_extract_%d_%d" i j) []
               [Ty.bitv n] (Ty.bitv (i - j + 1))
           )

--- a/src/standard/expr.mli
+++ b/src/standard/expr.mli
@@ -499,7 +499,7 @@ type builtin +=
      size [e] and significand of size [s] (hidden bit included). Those size are
      greater than 1 *)
   | Fp of int * int
-  (** [Fp(e, s): Bitv(1) -> Bitv(e) -> Bitv(s) -> Fp(e,s+1)]: bitvector literal.
+  (** [Fp(e, s): Bitv(1) -> Bitv(e) -> Bitv(s-1) -> Fp(e,s)]: bitvector literal.
       The IEEE-format is used for the conversion [sb^se^ss].
       All the NaN are converted to the same value. *)
   | Plus_infinity of int * int

--- a/src/standard/expr.mli
+++ b/src/standard/expr.mli
@@ -1420,4 +1420,3 @@ module Term : sig
   end
 
 end
-

--- a/src/typecheck/float.ml
+++ b/src/typecheck/float.ml
@@ -76,7 +76,7 @@ module Smtlib2 = struct
         | [ rm; b ] -> begin
             match Ty.view @@ T.ty b with
             | `Real -> F.real_to_fp e s rm b
-            | `Bitv _ -> F.ubv_to_fp e s rm b
+            | `Bitv _ -> F.sbv_to_fp e s rm b
             | `Float (_,_) -> F.to_fp e s rm b
             | _ -> Type._error env (Ast ast) (
                 Type.Expected ("a real, bitvector or float", Some (Term b)))

--- a/src/typecheck/logic.ml
+++ b/src/typecheck/logic.ml
@@ -28,6 +28,17 @@ module Smtlib2 = struct
     features      : features;
   }
 
+  let all = {
+    theories = [ `Core; `Arrays; `Bitvectors; `Floats; `Reals_Ints ];
+    features = {
+      free_sorts = true;
+      free_functions = true;
+      datatypes = true;
+      quantifiers = true;
+      arithmetic = `Regular;
+    };
+  }
+
   (*
   QF to disable the quantifier feature
   A or AX for the theory ArraysEx
@@ -49,16 +60,6 @@ module Smtlib2 = struct
         free_sorts = false;
         free_functions = false;
         datatypes = false;
-        quantifiers = true;
-        arithmetic = `Regular;
-      };
-    } in
-    let all = {
-      theories = [ `Core; `Arrays; `Bitvectors; `Floats; `Reals_Ints ];
-      features = {
-        free_sorts = true;
-        free_functions = true;
-        datatypes = true;
         quantifiers = true;
         arithmetic = `Regular;
       };

--- a/src/typecheck/logic.mli
+++ b/src/typecheck/logic.mli
@@ -39,6 +39,8 @@ module Smtlib2 : sig
   val parse : string -> t option
   (** Parses an smtlib logic string and returns its structured version. *)
 
+  val all: t
+  (** All the smtlib2 logic parsable *)
 end
 
 (** {2 All logics} *)

--- a/src/typecheck/tff.ml
+++ b/src/typecheck/tff.ml
@@ -831,7 +831,7 @@ module Make
         parse_quant T.all Ast.All env t [] [] t
 
       | { Ast.term = Ast.Binder (Ast.Ex, _, _); _ } ->
-        parse_quant T.all Ast.Ex env t [] [] t
+        parse_quant T.ex Ast.Ex env t [] [] t
 
       (* (Dis)Equality *)
       | { Ast.term = Ast.App ({Ast.term = Ast.Builtin Ast.Eq; _ }, l); _ } as t ->


### PR DESCRIPTION
Some various fixes for errors found by Bruno when testing the parser on a wide range of benchmarks and by using it in COLIBRI.

The two last commits are not fixes but are quite useful for easily extending the builtin functions.

(Oups, the commits are not based on a clean master I need to rebase them)