### PR TITLE
Complete rework of restrictions and filters

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,8 +19,8 @@ test: dune
 	dune exec -- tools/gentests.exe tests/
 	dune build $(FLAGS) @runtest
 
-test-promote:
-	dune exec -- tests/gentests.exe tests/
+test-promote: dune
+	dune exec -- tools/gentests.exe tests/
 	-dune build $(FLAGS) @runtest
 	dune promote $(FLAGS)
 

--- a/src/standard/expr.mli
+++ b/src/standard/expr.mli
@@ -603,9 +603,6 @@ end
 
 module Filter : sig
 
-  val reset : unit -> unit
-  (** Reset all filters. *)
-
   type ty_filter
   type term_filter
 
@@ -620,77 +617,6 @@ module Filter : sig
 
     val reset : unit -> unit
     (** Reset the filter to its default state. *)
-  end
-
-
-  module Quantifier : S
-  (** Filter for quantifiers.
-      Default is inactive (i.e. [!active = false]).
-      If active, trying to build a quantified term (i.e. containing a forall
-      or exists), will raise a [Filter_failed_term] exception. *)
-
-  (** Smtlib2 filters *)
-  module Smtlib2 : sig
-
-    module Linear_large : sig
-      include S
-      val div: term_filter
-      val mul: term_filter
-      val forbidden: term_filter
-    end
-    (** Filter for linear arithmetic.
-        Default is inactive (i.e. [!active = false]).
-        If active, only linear terms may be created. This affects both integer
-        and real arithmetic terms, but does not affect rational arithmetic
-        (as it is not in the scope of SMTLIB), nor does it affect
-        non-arithmetic terms.
-        This filters allows to multiply a literal and a terme with a head
-        symbol that is not a builtin arithmetic operator.
-    *)
-
-    module Linear_strict :  sig
-      include S
-      val div: term_filter
-      val mul: term_filter
-      val forbidden: term_filter
-    end
-    (** Filter for linear arithmetic.
-        Default is inactive (i.e. [!active = false]).
-        If active, only linear terms may be created. This affects both integer
-        and real arithmetic terms, but does not affect rational arithmetic
-        (as it is not in the scope of SMTLIB), nor does it affect
-        non-arithmetic terms.
-        This filters only allows constant symbols to be multiplied by a literal.
-    *)
-
-    module IDL :  sig
-      include S
-      val sub: term_filter
-      val minus: term_filter
-      val comp: term_filter
-      val forbidden: term_filter
-    end
-    (** Filter for Integer Difference Logic.
-        Default is inactive (i.e. [!active = false]).
-        If active only arithmetic term conforming to SMTLIB2's QF_IDL
-        ":language" specification will be accepted. Terms outside
-        of integer arithmetic are not affected by this filter. *)
-
-    module RDL : sig
-      include S
-      val add: term_filter
-      val sub: term_filter
-      val div: term_filter
-      val minus: term_filter
-      val comp: term_filter
-      val forbidden: term_filter
-    end
-    (** Filter for Real Difference Logic.
-        Default is inactive (i.e. [!active = false]).
-        If active only arithmetic term conforming to SMTLIB2's QF_RDL
-        ":language" specification will be accepted. Non-arithmetic
-        terms are not affected. *)
-
   end
 
 end

--- a/src/typecheck/arith.ml
+++ b/src/typecheck/arith.ml
@@ -17,16 +17,25 @@ module Smtlib2 = struct
        - x is a free constant or a term with top symbol not in Ints, and
        - c is a term of the form n or (- n) for some numeral n.
 
-     Additionally, even though it is never explicitly specified, we assume
-     that in the spec above, 'x' is also allowed to be a quantified variable
-     in logics which allow quantifiers.
+     Note that in this context "symbol" actually means a constant or
+     quantified variable.
+
+
+     Additionally, difference logic is a hell of specification. There are
+     about as many specs of difference logic than logics that use it.
+     Currently, there are three different difference logics:
+     - integer difference logic, as per the spec of QF_IDL
+     - real difference logic, as per the spec of QF_RDL
+     - UFIDL difference logic, as per the spec of QF_UFIDL
 
      There are therefore a few different "variants" of arithmetic that one
      can typecheck for:
      - regular arithmetic where everything is allowed
      - lenient linear arithmetic (as specified by AUFLIA)
      - strict linear arithmetic (as specified by other logics)
-     - difference logic
+     - integer difference logic
+     - real difference logic
+     - difference logic in UFIDL
   *)
   type arith =
     | Regular

--- a/src/typecheck/arith.ml
+++ b/src/typecheck/arith.ml
@@ -6,6 +6,488 @@ open Dolmen
 
 module Smtlib2 = struct
 
+  (* Classification of terms w.r.t. linearity, as per the specification
+     of the SMTLIB. Note that there exists 2 "versions" of linearity in the
+     SMTLIB: most of the linear arithmetic logics (e.g. AUFLIRA, LIA, LRA,
+     QF_LIA, QF_UFLIA, QF_UFLRA, QF_LRA, UFLRA)
+     specify linear terms as terms of the form c, ( * x c), ( * c x) where:
+       - x is a free constant of sort Int or Real and
+       - c is an integer or rational coefficient, respectively.
+     Whereas some logics (e.g. AUFLIA, QF_AUFLIA), use the following:
+       - x is a free constant or a term with top symbol not in Ints, and
+       - c is a term of the form n or (- n) for some numeral n.
+
+     Additionally, even though it is never explicitly specified, we assume
+     that in the spec above, 'x' is also allowed to be a quantified variable
+     in logics which allow quantifiers.
+
+     There are therefore a few different "variants" of arithmetic that one
+     can typecheck for:
+     - regular arithmetic where everything is allowed
+     - lenient linear arithmetic (as specified by AUFLIA)
+     - strict linear arithmetic (as specified by other logics)
+     - difference logic
+  *)
+  type arith =
+    | Regular
+    | Linear of [ `Large | `Strict ]
+    | Difference of [ `IDL | `RDL | `UFIDL ]
+
+  (* In order to establish the needed classification and correctly raise warnings
+     or errors, we first need a fine-grained view of terms according to an arithmetic
+     point of view, which is what the following represent. *)
+  type view =
+    | Numeral of string
+    | Decimal of string
+    | Negation of Term.t
+    | Addition of Term.t list
+    | Subtraction of Term.t list
+    | Division of Term.t * Term.t
+    | Complex_arith
+    | Variable of Dolmen.Id.t
+    | Constant of Dolmen.Id.t
+    | Top_symbol_not_in_arith
+
+  (* Results of filters that enforce restrictions such as linearity. Due to the
+     confusion created by the 2 different specs, some breach of restrictions
+     can be classified as warnings so that they can be recovered from. *)
+  type filter_res =
+    | Ok
+    | Warn of string
+    | Error of string
+
+  (* Low-level arithmetic view of terms *)
+  module View(Type : Tff_intf.S) = struct
+
+    (* View of arithmetic expressions *)
+    type t = view
+
+    let print fmt (t : t) =
+      match t with
+      | Numeral s -> Format.fprintf fmt "the numeral '%s'" s
+      | Decimal s -> Format.fprintf fmt "the decimal '%s'" s
+      | Negation _ -> Format.fprintf fmt "a negation"
+      | Addition _ -> Format.fprintf fmt "an addition"
+      | Subtraction _ -> Format.fprintf fmt "a subtraction"
+      | Division _ -> Format.fprintf fmt "a division"
+      | Complex_arith -> Format.fprintf fmt "a complex arithmetic expression"
+      | Variable v -> Format.fprintf fmt "the quantified variable %a" Dolmen.Id.print v
+      | Constant c -> Format.fprintf fmt "the constant symbol %a" Dolmen.Id.print c
+      | Top_symbol_not_in_arith ->
+        Format.fprintf fmt "an arbitrary (not arithmetic) expression"
+
+    let expect_error v v' expected =
+      Format.asprintf "expects %s but was given:\n- %a\n- %a"
+        expected print v print v'
+
+    let rec view ~parse version env (t : Term.t) =
+      match t.term with
+      | Symbol { Id.ns = Id.Value Id.Integer; name } -> Numeral name
+      | Symbol { Id.ns = Id.Value Id.Real; name } -> Decimal name
+
+      | App ({ term = Symbol { Id.ns = Id.Term; name = "-"; }; _ }, [e])
+        -> Negation e
+
+      | App ({ term = Symbol { Id.ns = Id.Term; name = "+"; }; _ }, ((_ :: _) as args))
+        -> Addition args
+
+      | App ({ term = Symbol { Id.ns = Id.Term; name = "-"; }; _ }, ((_ :: _) as args))
+        -> Subtraction args
+
+      | App ({ term = Symbol { Id.ns = Id.Term; name = "/"; }; _ }, [a; b])
+        -> Division (a, b)
+
+      (* Here, we assume that the arguments are coherent with the result of the
+         lookup (e.g. no arguments if Type.find_var returns a bound variables).
+         This is reasonable as this function should only be called on raw terms
+         that have been typechecked. *)
+      | Symbol id | App ({ term = Symbol id; _}, _) ->
+        begin match Type.find_var env id with
+          | `Letin (e, _, _) -> view ~parse version env e
+          | #Type.var -> Variable id
+          | #Type.not_found ->
+            begin match Type.find_global env id with
+              | #Type.cst -> Constant id
+              | #Type.not_found ->
+                begin match parse version env (Type.Id id) with
+                  | #Type.builtin_res -> Complex_arith
+                  | #Type.not_found -> Top_symbol_not_in_arith
+                end
+            end
+        end
+      | Builtin b | App ({ term = Builtin b; _ }, _) ->
+        begin match parse version env (Type.Builtin b) with
+          | #Type.builtin_res -> Complex_arith
+          | #Type.not_found -> Top_symbol_not_in_arith
+        end
+
+      (* Catch-all *)
+      | _ -> Top_symbol_not_in_arith
+
+    let rec difference_count view t :
+      [ `Ok of Dolmen.Id.t * int | `Error of string ] =
+      match (view t : view) with
+      | Variable v -> `Ok (v, 1)
+      | Constant c -> `Ok (c, 1)
+      | Addition l -> difference_count_list view l
+      | v -> `Error (
+          Format.asprintf "addition in real difference logic expects \
+                           either variables/constants or an addition of \
+                           variables/constants, but was here given %a" print v)
+
+    and difference_count_list view = function
+      | h :: r ->
+        begin match difference_count view h with
+          | (`Error _) as res -> res
+          | `Ok (symb, n) ->
+            difference_count_list_aux view n symb r
+          end
+      | [] -> assert false
+
+    and difference_count_list_aux view n s = function
+      | [] -> `Ok (s, n)
+      | t :: r ->
+        begin match difference_count view t with
+          | (`Error _) as res -> res
+          | `Ok (s', n') ->
+            if Dolmen.Id.equal s s' then
+              difference_count_list_aux view (n + n') s r
+            else
+              `Error (
+                Format.asprintf "addition in real difference logic expects
+                                 n-th times the same variable/constant, but was
+                                 here applied to %a and %a which are different"
+                  Dolmen.Id.print s Dolmen.Id.print s')
+        end
+
+
+  end
+
+  module Classification = struct
+
+    (* We can now classify terms according to the following kinds:
+       - coefficients, i.e. integer or rational literals, as per the spec above.
+       Coefficients consists of:
+         + raw literals (i.e. in the Id.Value namespace)
+         + the negation of (i.e. application of term symbol "-" to) a raw literal
+         + the division of (i.e. an application of term symbol "/" to) of an
+           integer coeficient by a raw literal different from zero.
+       - complex arithmetic expressions, i.e. expressions whose top-level symbol
+         is a builtin symbol of arithmetic (e.g. '+', '-', '*', ...), but that
+         are not coefficients.
+       - nullary constant symbols (standalone, or applied to the empty list),
+         and quantified variables
+       - all other expressions *)
+    type t =
+      | Int_coefficient
+      | Rat_coefficient
+      | Complex_arith
+      | Variable_or_constant
+      | Top_symbol_not_in_arith
+
+    let print fmt (t: t) =
+      match t with
+      | Int_coefficient -> Format.fprintf fmt "an integer coefficient"
+      | Rat_coefficient -> Format.fprintf fmt "a rational coefficient"
+      | Complex_arith -> Format.fprintf fmt "a complex arithmetic expression"
+      | Variable_or_constant -> Format.fprintf fmt "a symbol (or quantified variable)"
+      | Top_symbol_not_in_arith ->
+        Format.fprintf fmt "an arbitrary expression with top symbol not in Arithmetic"
+
+    let expect_error c c' expected =
+      Format.asprintf "expects %s but was given:\n- %a\n- %a"
+        expected print c print c'
+
+    let rec classify view t =
+      match (view t: view) with
+      | Numeral _ -> Int_coefficient
+      | Decimal _ -> Rat_coefficient
+      | Addition _ -> Complex_arith
+      | Subtraction _ -> Complex_arith
+      | Negation t' ->
+        begin match (view t': view) with
+          | Numeral _ -> Int_coefficient
+          | Decimal _ -> Rat_coefficient
+          | _ -> Complex_arith
+        end
+      | Division (numerator, denominator) ->
+        begin match (classify view numerator, view denominator) with
+          | Int_coefficient, Numeral s when s <> "0"
+            -> Rat_coefficient
+          | _ -> Complex_arith
+        end
+      | Complex_arith -> Complex_arith
+      | Variable _ | Constant _ -> Variable_or_constant
+      | Top_symbol_not_in_arith -> Top_symbol_not_in_arith
+
+
+  end
+
+  (* Filter for arithmetic *)
+  module Filter(Type : Tff_intf.S) = struct
+
+    module V = View(Type)
+
+    let bad_arity operator logic n =
+      Error (Format.asprintf
+               "%s in %s must have exactly %d arguments" operator logic n)
+
+    let forbidden operator logic =
+      Error (Format.asprintf "%s is not allowed in %s" operator logic)
+
+    (* Filter helpers / Individual restriction filters *)
+
+    let minus_dl parse version env = function
+      | [ a ] ->
+        begin match V.view ~parse version env a with
+          | Numeral _
+          | Decimal _ -> Ok
+          | v ->
+            Error (Format.asprintf
+                     "unary subtraction in difference logic expects \
+                      a literal, but was given %a"
+                     V.print v)
+        end
+      | _ -> bad_arity "unary subtraction" "difference logic" 1
+
+    let sub_idl parse version env = function
+      | [ a; b ] ->
+        begin match Classification.classify (V.view ~parse version env) a,
+                    Classification.classify (V.view ~parse version env) b with
+        | Variable_or_constant, Variable_or_constant -> Ok
+        | v, v' ->
+          Error (Format.asprintf "subtraction in difference logic %s"
+                   (Classification.expect_error v v' "two constants/variables"))
+        end
+      | _ -> bad_arity "subtraction" "integer difference logic" 2
+
+    let sub_rdl parse version env = function
+      | [ a; b ] ->
+        begin match V.difference_count (V.view ~parse version env) a,
+                    V.difference_count (V.view ~parse version env) b with
+        | `Error msg, _
+        | _, `Error msg
+          -> Error msg
+        | `Ok (_, n), `Ok (_, n') ->
+          if n = n' then Ok
+          else Error (
+              Format.asprintf "subtraction in real difference logic \
+                               expects both sides to be sums of the same \
+                               length, but here the sums have lengths \
+                               %d and %d" n n')
+        end
+      | _ -> bad_arity "subtraction" "real difference logic" 2
+
+    let op_ufidl parse version env args =
+      let rec aux non_numeral_seen = function
+        | [] -> Ok
+        | t :: r ->
+          begin match V.view ~parse version env t with
+            | Numeral _ -> aux non_numeral_seen r
+            | _ ->
+              if non_numeral_seen then
+                Error (Format.asprintf "subtraction in difference logic (QF_UFIDL version) \
+                                        expects all but at most one of its arguments to be \
+                                        numerals")
+              else
+                aux true r
+          end
+      in
+      aux false args
+
+    let add_rdl parse version env args =
+      match V.difference_count_list (V.view ~parse version env) args with
+      | `Ok _ -> Ok
+      | `Error msg -> Error msg
+
+    let div_linear parse version env = function
+      | [ a; b ] ->
+        begin match Classification.classify (V.view ~parse version env) a with
+          | Int_coefficient ->
+            begin match V.view ~parse version env b with
+              | Numeral "0" ->
+                Error (Format.asprintf "division in linear arithmetic \
+                                        expects a non-zero denominator")
+              | Numeral _ -> Ok
+              | v ->
+                Error (Format.asprintf "division in linear arithmetic \
+                                        expects a constant positive \
+                                        integer literal as denominator, \
+                                        but was given %a"
+                         V.print v)
+            end
+          | c ->
+            Error (Format.asprintf "division in linear arithmetic \
+                                    expects as first argument an integer \
+                                    coeficient, i.e. either a raw integer \
+                                    literal, or the negation of one, but \
+                                    here was given a %a"
+                     Classification.print c)
+        end
+      | _ -> bad_arity "division" "linear arithmetic" 2
+
+    let mul_linear_msg ~strict c c' =
+      Format.asprintf "multiplication in %slinear arithmetic %s"
+        (if strict then "strict " else "")
+        (Classification.expect_error c c'
+           (if strict
+            then "an integer or rational literal and a symbol (variable or constant)"
+            else "an integer or rational literal and a non-arithmetic expression"))
+
+    let mul_linear ~strict parse version env = function
+      | [ a; b ] ->
+        begin match Classification.classify (V.view ~parse version env) a,
+                    Classification.classify (V.view ~parse version env) b with
+        | (Int_coefficient | Rat_coefficient), Variable_or_constant
+        | Variable_or_constant, (Int_coefficient | Rat_coefficient)
+          -> Ok
+        | ((Int_coefficient | Rat_coefficient) as c), (Top_symbol_not_in_arith as c')
+        | (Top_symbol_not_in_arith as c), ((Int_coefficient | Rat_coefficient) as c')
+          ->
+          if strict then Warn (mul_linear_msg ~strict c c') else Ok
+        | c, c' -> Error (mul_linear_msg ~strict c c')
+        end
+      | _ -> bad_arity "multiplication" "linear arithmetic" 2
+
+    let comp_idl parse version env = function
+      | [ a; b ] ->
+        begin match V.view ~parse version env a,
+                    V.view ~parse version env b with
+        | (Variable _ | Constant _),
+          (Variable _ | Constant _) -> Ok
+        (* If the first argument is a subtraction, it must have passed
+           the sub_wrapper filter, which means both its side must be
+           constants, so no need to check it here again. *)
+        | Subtraction _, Numeral _ -> Ok
+        | Subtraction _, Negation _ -> Ok
+        (* error case *)
+        | v, v' ->
+          Error (Format.asprintf "comparison in integer difference logic %s"
+                   (V.expect_error v v'
+                      "a substraction on the left and a (possibly negated) \
+                       integer literal on the right"))
+        end
+      | _ -> bad_arity "comparison" "integer difference logic" 2
+
+    let comp_rdl parse version env = function
+      | [ a; b ] ->
+        begin match V.view ~parse version env a,
+                    V.view ~parse version env b with
+        | (Variable _ | Constant _),
+          (Variable _ | Constant _) -> Ok
+        (* If the first argument is a subtraction, it must have passed
+           the sub_wrapper filter, which means both its side must be
+           constants, so no need to check it here again. *)
+        | Subtraction _, Numeral _ -> Ok
+        | Subtraction _, Negation _ -> Ok
+        (* Syntactic sugar *)
+        | Subtraction [x; y], Division _ ->
+          begin match V.difference_count (V.view ~parse version env) x,
+                      V.difference_count (V.view ~parse version env) y with
+          | `Error msg, _
+          | _, `Error msg -> Error msg
+          | `Ok (_, n), `Ok (_, n') ->
+            (* since the sub filter passed, we should have n = n' *)
+            if n = 1 && n' = 1 then Ok
+            else
+              Error (
+                Format.asprintf "in real difference logic, when comparing \
+                                 the result of a subtraction with a rational \
+                                 number, each side of the subtraction can only \
+                                 contain a single variable/constant, but here there
+                                 was %d" n)
+          end
+        (* Error case *)
+        | v, v' ->
+          Error (
+            Format.asprintf "comparison in difference logic %s"
+              (V.expect_error v v'
+                 "a subtraction on the left and a (possibly negated) \
+                  integer literal on the right"))
+        end
+      | _ -> bad_arity "comparison" "real difference logic" 2
+
+
+    (* Global filters *)
+
+    let minus arith parse version env args =
+      match arith with
+      | Regular -> Ok
+      | Linear _ -> Ok
+      | Difference (`IDL | `RDL) ->
+        minus_dl parse version env args
+      | Difference `UFIDL ->
+        forbidden "unary subtraction" "difference logic (QF_UFIDL variant)"
+
+    let sub arith parse version env args =
+      match arith with
+      | Regular -> Ok
+      | Linear _ -> Ok
+      | Difference `IDL -> sub_idl parse version env args
+      | Difference `RDL -> sub_rdl parse version env args
+      | Difference `UFIDL -> op_ufidl parse version env args
+
+    let add arith parse version env args =
+      match arith with
+      | Regular -> Ok
+      | Linear _ -> Ok
+      | Difference `IDL -> forbidden "addition" "integer difference logic"
+      | Difference `RDL -> add_rdl parse version env args
+      | Difference `UFIDL -> op_ufidl parse version env args
+
+    let mul arith parse version env args =
+      match arith with
+      | Regular -> Ok
+      | Linear `Strict -> mul_linear ~strict:true parse version env args
+      | Linear `Large -> mul_linear ~strict:false parse version env args
+      | Difference `IDL -> forbidden "multiplication" "integer difference logic"
+      | Difference `RDL -> forbidden "multiplication" "real difference logic"
+      | Difference `UFIDL -> forbidden "multiplication" "difference logic (QF_UFIDL variant)"
+
+    let div arith parse version env args =
+      match arith with
+      | Regular -> Ok
+      | Linear _ -> div_linear parse version env args
+      | Difference `IDL -> forbidden "division" "integer difference logic"
+      | Difference `RDL -> div_linear parse version env args
+      | Difference `UFIDL -> forbidden "division" "difference logic (QF_UFIDL variant)"
+
+    let ediv arith _args =
+      match arith with
+      | Regular -> Ok
+      | Linear _ -> forbidden "euclidean division" "linear arithmetic"
+      | Difference _ -> forbidden "euclidean division" "difference logic"
+
+    let mod_ arith _args =
+      match arith with
+      | Regular -> Ok
+      | Linear _ -> forbidden "mod" "linear arithmetic"
+      | Difference _ -> forbidden "mod" "difference logic"
+
+    let abs arith _args =
+      match arith with
+      | Regular -> Ok
+      | Linear _ -> forbidden "abs" "linear arithmetic"
+      | Difference _ -> forbidden "abs" "difference logic"
+
+    let comp arith parse version env args =
+      match arith with
+      | Regular -> Ok
+      | Linear _ -> Ok
+      | Difference `IDL -> comp_idl parse version env args
+      | Difference `RDL -> comp_rdl parse version env args
+      | Difference `UFIDL -> Ok
+
+    let divisible arith _args =
+      match arith with
+      | Regular -> Ok
+      | Linear _ -> forbidden "divisible" "linear arithmetic"
+      | Difference _ -> forbidden "divisible" "difference logic"
+
+  end
+
+  (* Integer arithmetics *)
+
   module Int = struct
 
     module Tff
@@ -13,7 +495,24 @@ module Smtlib2 = struct
         (Ty : Dolmen.Intf.Ty.Smtlib_Int with type t := Type.Ty.t)
         (T : Dolmen.Intf.Term.Smtlib_Int with type t := Type.T.t) = struct
 
-      let parse _version env s =
+      module F = Filter(Type)
+
+      type _ Type.warn +=
+        | Restriction : string -> Dolmen.Term.t Type.warn
+
+      type _ Type.err +=
+        | Forbidden : string -> Dolmen.Term.t Type.err
+
+      let check env filter ast args =
+        match filter args with
+        | Ok -> ()
+        | Warn msg -> Type._warn env (Ast ast) (Restriction msg)
+        | Error msg -> Type._error env (Ast ast) (Forbidden msg)
+
+      let check1 env filter ast a = check env filter ast [a]
+      let check2 env filter ast a b = check env filter ast [a; b]
+
+      let rec parse ~arith version env s =
         match s with
         (* type *)
         | Type.Id { Id.ns = Id.Sort; name = "Int"; } ->
@@ -26,25 +525,49 @@ module Smtlib2 = struct
           begin match name with
             | "-" ->
               `Term (fun ast args -> match args with
-                  | [x] -> T.minus (Type.parse_term env x)
-                  | _ -> Base.term_app_left (module Type) env "-" T.sub ast args
+                  | [x] ->
+                    check env (F.minus arith (parse ~arith) version env) ast args;
+                    T.minus (Type.parse_term env x)
+                  | _ ->
+                    Base.term_app_left (module Type) env "-" T.sub ast args
+                      ~check:(check env (F.sub arith (parse ~arith) version env))
                 )
-            | "+" -> `Term (Base.term_app_left (module Type) env "+" T.add)
-            | "*" -> `Term (Base.term_app_left (module Type) env "*" T.mul)
-            | "div" -> `Term (Base.term_app_left (module Type) env "div" T.div)
-            | "mod" -> `Term (Base.term_app2 (module Type) env "mod" T.rem)
-            | "abs" -> `Term (Base.term_app1 (module Type) env "abs" T.abs)
-            | "<=" -> `Term (Base.term_app_chain (module Type) env "<=" T.le)
-            | "<" -> `Term (Base.term_app_chain (module Type) env "<" T.lt)
-            | ">=" -> `Term (Base.term_app_chain (module Type) env ">=" T.ge)
-            | ">" -> `Term (Base.term_app_chain (module Type) env ">" T.gt)
+            | "+" ->
+              `Term (Base.term_app_left (module Type) env "+" T.add
+                    ~check:(check env (F.add arith (parse ~arith) version env)))
+            | "*" ->
+              `Term (Base.term_app_left (module Type) env "*" T.mul
+                       ~check:(check env (F.mul arith (parse ~arith) version env)))
+            | "div" ->
+              `Term (Base.term_app_left (module Type) env "div" T.div
+                       ~check:(check env (F.ediv arith)))
+            | "mod" ->
+              `Term (Base.term_app2 (module Type) env "mod" T.rem
+                    ~check:(check2 env (F.mod_ arith)))
+            | "abs" ->
+              `Term (Base.term_app1 (module Type) env "abs" T.abs
+                    ~check:(check1 env (F.abs arith)))
+            | "<=" ->
+              `Term (Base.term_app_chain (module Type) env "<=" T.le
+                    ~check:(check env (F.comp arith (parse ~arith) version env)))
+            | "<" ->
+              `Term (Base.term_app_chain (module Type) env "<" T.lt
+                    ~check:(check env (F.comp arith (parse ~arith) version env)))
+            | ">=" ->
+              `Term (Base.term_app_chain (module Type) env ">=" T.ge
+                    ~check:(check env (F.comp arith (parse ~arith) version env)))
+            | ">" ->
+              `Term (Base.term_app_chain (module Type) env ">" T.gt
+                    ~check:(check env (F.comp arith (parse ~arith) version env)))
             | _ -> Base.parse_id name
                      ~k:(function _ -> `Not_found)
                      ~err:(Base.bad_ty_index_arity (module Type) env)
                      [
                        "divisible", `Unary (function n ->
                            `Term (Base.term_app1 (module Type) env
-                                    "divisible" (T.divisible n)));
+                                    "divisible" (T.divisible n)
+                                    ~check:(check1 env (F.divisible arith)))
+                         );
                      ]
           end
         | _ -> `Not_found
@@ -59,7 +582,21 @@ module Smtlib2 = struct
         (Ty : Dolmen.Intf.Ty.Smtlib_Real with type t := Type.Ty.t)
         (T : Dolmen.Intf.Term.Smtlib_Real with type t := Type.T.t) = struct
 
-      let parse _version env s =
+      module F = Filter(Type)
+
+      type _ Type.warn +=
+        | Restriction : string -> Dolmen.Term.t Type.warn
+
+      type _ Type.err +=
+        | Forbidden : string -> Dolmen.Term.t Type.err
+
+      let check env filter ast args =
+        match filter args with
+        | Ok -> ()
+        | Warn msg -> Type._warn env (Ast ast) (Restriction msg)
+        | Error msg -> Type._error env (Ast ast) (Forbidden msg)
+
+      let rec parse ~arith version env s =
         match s with
         (* type *)
         | Type.Id { Id.ns = Id.Sort; name = "Real"; } ->
@@ -72,16 +609,34 @@ module Smtlib2 = struct
           begin match name with
             | "-" -> `Term (fun ast args ->
                 match args with
-                | [x] -> T.minus (Type.parse_term env x)
-                | _ -> Base.term_app_left (module Type) env "-" T.sub ast args
+                | [x] ->
+                  check env (F.minus arith (parse ~arith) version env) ast args;
+                  T.minus (Type.parse_term env x)
+                | _ ->
+                  Base.term_app_left (module Type) env "-" T.sub ast args
+                    ~check:(check env (F.sub arith (parse ~arith) version env))
               )
-            | "+" -> `Term (Base.term_app_left (module Type) env "+" T.add)
-            | "*" -> `Term (Base.term_app_left (module Type) env "*" T.mul)
-            | "/" -> `Term (Base.term_app_left (module Type) env "/" T.div)
-            | "<=" -> `Term (Base.term_app_chain (module Type) env "<=" T.le)
-            | "<" -> `Term (Base.term_app_chain (module Type) env "<" T.lt)
-            | ">=" -> `Term (Base.term_app_chain (module Type) env ">=" T.ge)
-            | ">" -> `Term (Base.term_app_chain (module Type) env ">" T.gt)
+            | "+" ->
+              `Term (Base.term_app_left (module Type) env "+" T.add
+                       ~check:(check env (F.add arith (parse ~arith) version env)))
+            | "*" ->
+              `Term (Base.term_app_left (module Type) env "*" T.mul
+                       ~check:(check env (F.mul arith (parse ~arith) version env)))
+            | "/" ->
+              `Term (Base.term_app_left (module Type) env "/" T.div
+                       ~check:(check env (F.div arith (parse ~arith) version env)))
+            | "<=" ->
+              `Term (Base.term_app_chain (module Type) env "<=" T.le
+                       ~check:(check env (F.comp arith (parse ~arith) version env)))
+            | "<" ->
+              `Term (Base.term_app_chain (module Type) env "<" T.lt
+                       ~check:(check env (F.comp arith (parse ~arith) version env)))
+            | ">=" ->
+              `Term (Base.term_app_chain (module Type) env ">=" T.ge
+                       ~check:(check env (F.comp arith (parse ~arith) version env)))
+            | ">" ->
+              `Term (Base.term_app_chain (module Type) env ">" T.gt
+                       ~check:(check env (F.comp arith (parse ~arith) version env)))
             | _ -> `Not_found
           end
         | _ -> `Not_found
@@ -97,8 +652,23 @@ module Smtlib2 = struct
         (T : Dolmen.Intf.Term.Smtlib_Real_Int with type t := Type.T.t
                                                and type ty := Type.Ty.t) = struct
 
+      module F = Filter(Type)
+
+      type _ Type.warn +=
+        | Restriction : string -> Dolmen.Term.t Type.warn
+
       type _ Type.err +=
+        | Forbidden : string -> Dolmen.Term.t Type.err
         | Expected_arith_type : Type.Ty.t -> Term.t Type.err
+
+      let check env filter ast args =
+        match filter args with
+        | Ok -> ()
+        | Warn msg -> Type._warn env (Ast ast) (Restriction msg)
+        | Error msg -> Type._error env (Ast ast) (Forbidden msg)
+
+      let check1 env filter ast a = check env filter ast [a]
+      let check2 env filter ast a b = check env filter ast [a; b]
 
       let dispatch1 env (mk_int, mk_real) ast t =
         match Ty.view @@ T.ty t with
@@ -121,7 +691,7 @@ module Smtlib2 = struct
         | `Int, `Int -> mk_real (T.Int.to_real a) (T.Int.to_real b)
         | _ -> mk_real a b
 
-      let parse _version env s =
+      let rec parse ~arith version env s =
         match s with
 
         (* type *)
@@ -143,47 +713,58 @@ module Smtlib2 = struct
                 match args with
                 | [_] ->
                   Base.term_app1_ast (module Type) env "-"
-                    (dispatch1 env (T.Int.minus, T.Real.minus))
-                    ast args
+                    (dispatch1 env (T.Int.minus, T.Real.minus)) ast args
+                    ~check:(check1 env (F.minus arith (parse ~arith) version env))
                 | _ ->
                   Base.term_app_left_ast (module Type) env "-"
-                    (dispatch2 env (T.Int.sub, T.Real.sub))
-                    ast args
+                    (dispatch2 env (T.Int.sub, T.Real.sub)) ast args
+                    ~check:(check env (F.sub arith (parse ~arith) version env))
               )
             | "+" ->
               `Term (Base.term_app_left_ast (module Type) env "+"
-                       (dispatch2 env (T.Int.add, T.Real.add)))
+                       (dispatch2 env (T.Int.add, T.Real.add))
+                       ~check:(check env (F.add arith (parse ~arith) version env)))
             | "*" ->
               `Term (Base.term_app_left_ast (module Type) env "*"
-                       (dispatch2 env (T.Int.mul, T.Real.mul)))
+                       (dispatch2 env (T.Int.mul, T.Real.mul))
+                       ~check:(check env (F.mul arith (parse ~arith) version env)))
             | "div" ->
-              `Term (Base.term_app_left (module Type) env "div" T.Int.div)
+              `Term (Base.term_app_left (module Type) env "div" T.Int.div
+                       ~check:(check env (F.ediv arith)))
             | "mod" ->
-              `Term (Base.term_app2 (module Type) env "mod" T.Int.rem)
+              `Term (Base.term_app2 (module Type) env "mod" T.Int.rem
+                       ~check:(check2 env (F.mod_ arith)))
             | "abs" ->
-              `Term (Base.term_app1 (module Type) env "abs" T.Int.abs)
+              `Term (Base.term_app1 (module Type) env "abs" T.Int.abs
+                       ~check:(check1 env (F.abs arith)))
             | "/" ->
               `Term (Base.term_app_left_ast (module Type) env "/"
-                       (promote_int_to_real env T.Real.div))
+                       (promote_int_to_real env T.Real.div)
+                       ~check:(check env (F.div arith (parse ~arith) version env)))
             | "<=" ->
               `Term (Base.term_app_chain_ast (module Type) env "<="
-                       (dispatch2 env (T.Int.le, T.Real.le)))
+                       (dispatch2 env (T.Int.le, T.Real.le))
+                       ~check:(check env (F.comp arith (parse ~arith) version env)))
             | "<" ->
               `Term (Base.term_app_chain_ast (module Type) env "<"
-                       (dispatch2 env (T.Int.lt, T.Real.lt)))
+                       (dispatch2 env (T.Int.lt, T.Real.lt))
+                       ~check:(check env (F.comp arith (parse ~arith) version env)))
             | ">=" ->
               `Term (Base.term_app_chain_ast (module Type) env ">="
-                       (dispatch2 env (T.Int.ge, T.Real.ge)))
+                       (dispatch2 env (T.Int.ge, T.Real.ge))
+                       ~check:(check env (F.comp arith (parse ~arith) version env)))
             | ">" ->
               `Term (Base.term_app_chain_ast (module Type) env ">"
-                       (dispatch2 env (T.Int.gt, T.Real.gt)))
+                       (dispatch2 env (T.Int.gt, T.Real.gt))
+                       ~check:(check env (F.comp arith (parse ~arith) version env)))
             | _ -> Base.parse_id name
                      ~k:(function _ -> `Not_found)
                      ~err:(Base.bad_ty_index_arity (module Type) env)
                      [
                        "divisible", `Unary (function n ->
                            `Term (Base.term_app1 (module Type) env
-                                    "divisible" (T.Int.divisible n)));
+                                    "divisible" (T.Int.divisible n)
+                                    ~check:(check1 env (F.divisible arith))));
                      ]
           end
         | _ -> `Not_found

--- a/src/typecheck/arith.ml
+++ b/src/typecheck/arith.ml
@@ -330,7 +330,7 @@ module Smtlib2 = struct
                                     expects as first argument an integer \
                                     coeficient, i.e. either a raw integer \
                                     literal, or the negation of one, but \
-                                    here was given a %a"
+                                    here was given %a"
                      Classification.print c)
         end
       | _ -> bad_arity "division" "linear arithmetic" 2

--- a/src/typecheck/arith.mli
+++ b/src/typecheck/arith.mli
@@ -2,6 +2,13 @@
 (** Smtlib Integer and Real Arithmetic *)
 module Smtlib2 : sig
 
+  type arith =
+    | Regular
+    | Linear of [ `Large | `Strict ]
+    | Difference of [ `IDL | `RDL | `UFIDL ] (**)
+  (** The different type of arithmetic restrictions, see the comment in
+      arith.ml for more information. *)
+
   (** Standalone Integer arithmetic *)
   module Int : sig
 
@@ -10,7 +17,19 @@ module Smtlib2 : sig
         (Ty : Dolmen.Intf.Ty.Smtlib_Int with type t := Type.Ty.t)
         (T : Dolmen.Intf.Term.Smtlib_Int with type t := Type.T.t) : sig
 
-      val parse : Dolmen_smtlib2.version -> Type.builtin_symbols
+      type _ Type.warn +=
+        | Restriction : string -> Dolmen.Term.t Type.warn
+        (** Warning for expressions which tecnically do not respect the strict
+            spec but respect the large spec. *)
+      (** Arithmetic type-checking warnings *)
+
+      type _ Type.err +=
+        | Forbidden : string -> Dolmen.Term.t Type.err
+        (** Error for expressions which do not respect the spec. *)
+      (** Arithmetic type-checking errors *)
+
+      val parse : arith:arith -> Dolmen_smtlib2.version -> Type.builtin_symbols
+      (** Parsing function for type-checking *)
     end
 
   end
@@ -23,7 +42,19 @@ module Smtlib2 : sig
         (Ty : Dolmen.Intf.Ty.Smtlib_Real with type t := Type.Ty.t)
         (T : Dolmen.Intf.Term.Smtlib_Real with type t := Type.T.t) : sig
 
-      val parse : Dolmen_smtlib2.version -> Type.builtin_symbols
+      type _ Type.warn +=
+        | Restriction : string -> Dolmen.Term.t Type.warn
+        (** Warning for expressions which tecnically do not respect the strict
+            spec but respect the large spec. *)
+      (** Arithmetic type-checking warnings *)
+
+      type _ Type.err +=
+        | Forbidden : string -> Dolmen.Term.t Type.err
+        (** Error for expressions which do not respect the spec. *)
+      (** Arithmetic type-checking errors *)
+
+      val parse : arith:arith -> Dolmen_smtlib2.version -> Type.builtin_symbols
+      (** Parsing function for type-checking *)
     end
 
   end
@@ -37,13 +68,22 @@ module Smtlib2 : sig
         (T : Dolmen.Intf.Term.Smtlib_Real_Int with type t := Type.T.t
                                                and type ty := Type.Ty.t) : sig
 
+      type _ Type.warn +=
+        | Restriction : string -> Dolmen.Term.t Type.warn
+        (** Warning for expressions which tecnically do not respect the strict
+            spec but respect the large spec. *)
+      (** Arithmetic type-checking warnings *)
+
       type _ Type.err +=
+        | Forbidden : string -> Dolmen.Term.t Type.err
+        (** Error for expressions which do not respect the spec. *)
         | Expected_arith_type : Type.Ty.t -> Dolmen.Term.t Type.err
         (** Error raised when an arithmetic type was expected (i.e. either
             int or real), but another type was found. *)
       (** Additional errors specific to arithmetic typing. *)
 
-      val parse : Dolmen_smtlib2.version -> Type.builtin_symbols
+      val parse : arith:arith -> Dolmen_smtlib2.version -> Type.builtin_symbols
+      (** Parsing function for type-checking *)
 
     end
 

--- a/src/typecheck/base.ml
+++ b/src/typecheck/base.ml
@@ -171,13 +171,13 @@ let map_chain
 
 let app0
     (type env) (module Type : Tff_intf.S with type env = env)
-    env name ret =
-  make_op0 (module Type) env name (fun _ () -> ret)
+    ?(check=(fun _ -> ())) env name ret =
+  make_op0 (module Type) env name (fun ast () -> check ast; ret)
 
 let app0_ast
     (type env) (module Type : Tff_intf.S with type env = env)
-    env name mk =
-  make_op0 (module Type) env name (fun ast () -> mk ast)
+    ?(check=(fun _ -> ())) env name mk =
+  make_op0 (module Type) env name (fun ast () -> check ast; mk ast)
 
 
 (* Unary applications *)
@@ -185,26 +185,30 @@ let app0_ast
 let ty_app1
     (type env) (type ty)
     (module Type : Tff_intf.S with type env = env and type Ty.t = ty)
-    env name mk =
-  make_op1 (module Type) env name (fun _ t -> mk (Type.parse_ty env t))
+    ?(check=(fun _ _ -> ())) env name mk =
+  make_op1 (module Type) env name
+    (fun ast t -> check ast t; mk (Type.parse_ty env t))
 
 let ty_app1_ast
     (type env) (type ty)
     (module Type : Tff_intf.S with type env = env and type Ty.t = ty)
-    env name mk =
-  make_op1 (module Type) env name (fun ast t -> mk ast (Type.parse_ty env t))
+    ?(check=(fun _ _ -> ())) env name mk =
+  make_op1 (module Type) env name
+    (fun ast t -> check ast t; mk ast (Type.parse_ty env t))
 
 let term_app1
     (type env) (type term)
     (module Type : Tff_intf.S with type env = env and type T.t = term)
-    env name mk =
-  make_op1 (module Type) env name (fun _ t -> mk (Type.parse_term env t))
+    ?(check=(fun _ _ -> ())) env name mk =
+  make_op1 (module Type) env name
+    (fun ast t -> check ast t; mk (Type.parse_term env t))
 
 let term_app1_ast
     (type env) (type term)
     (module Type : Tff_intf.S with type env = env and type T.t = term)
-    env name mk =
-  make_op1 (module Type) env name (fun ast t -> mk ast (Type.parse_term env t))
+    ?(check=(fun _ _ -> ())) env name mk =
+  make_op1 (module Type) env name
+    (fun ast t -> check ast t; mk ast (Type.parse_term env t))
 
 
 (* Binary applications *)
@@ -212,30 +216,30 @@ let term_app1_ast
 let ty_app2
     (type env) (type ty)
     (module Type : Tff_intf.S with type env = env and type Ty.t = ty)
-    env name mk =
-  make_op2 (module Type) env name (fun _ (a, b) ->
-      mk (Type.parse_ty env a) (Type.parse_ty env b))
+    ?(check=(fun _ _ _ -> ())) env name mk =
+  make_op2 (module Type) env name (fun ast (a, b) ->
+      check ast a b; mk (Type.parse_ty env a) (Type.parse_ty env b))
 
 let ty_app2_ast
     (type env) (type ty)
     (module Type : Tff_intf.S with type env = env and type Ty.t = ty)
-    env name mk =
+    ?(check=(fun _ _ _ -> ())) env name mk =
   make_op2 (module Type) env name (fun ast (a, b) ->
-      mk ast (Type.parse_ty env a) (Type.parse_ty env b))
+      check ast a b; mk ast (Type.parse_ty env a) (Type.parse_ty env b))
 
 let term_app2
     (type env) (type term)
     (module Type : Tff_intf.S with type env = env and type T.t = term)
-    env name mk =
-  make_op2 (module Type) env name (fun _ (a, b) ->
-      mk (Type.parse_term env a) (Type.parse_term env b))
+    ?(check=(fun _ _ _ -> ())) env name mk =
+  make_op2 (module Type) env name (fun ast (a, b) ->
+      check ast a b; mk (Type.parse_term env a) (Type.parse_term env b))
 
 let term_app2_ast
     (type env) (type term)
     (module Type : Tff_intf.S with type env = env and type T.t = term)
-    env name mk =
+    ?(check=(fun _ _ _ -> ())) env name mk =
   make_op2 (module Type) env name (fun ast (a, b) ->
-      mk ast (Type.parse_term env a) (Type.parse_term env b))
+      check ast a b; mk ast (Type.parse_term env a) (Type.parse_term env b))
 
 
 (* Ternary applications *)
@@ -243,29 +247,33 @@ let term_app2_ast
 let ty_app3
     (type env) (type ty)
     (module Type : Tff_intf.S with type env = env and type Ty.t = ty)
-    env name mk =
-  make_op3 (module Type) env name (fun _ (a, b, c) ->
+    ?(check=(fun _ _ _ _ -> ())) env name mk =
+  make_op3 (module Type) env name (fun ast (a, b, c) ->
+      check ast a b c;
       mk (Type.parse_ty env a) (Type.parse_ty env b) (Type.parse_ty env c))
 
 let ty_app3_ast
     (type env) (type ty)
     (module Type : Tff_intf.S with type env = env and type Ty.t = ty)
-    env name mk =
+    ?(check=(fun _ _ _ _ -> ())) env name mk =
   make_op3 (module Type) env name (fun ast (a, b, c) ->
+      check ast a b c;
       mk ast (Type.parse_ty env a) (Type.parse_ty env b) (Type.parse_ty env c))
 
 let term_app3
     (type env) (type term)
     (module Type : Tff_intf.S with type env = env and type T.t = term)
-    env name mk =
-  make_op3 (module Type) env name (fun _ (a, b, c) ->
+    ?(check=(fun _ _ _ _ -> ())) env name mk =
+  make_op3 (module Type) env name (fun ast (a, b, c) ->
+      check ast a b c;
       mk (Type.parse_term env a) (Type.parse_term env b) (Type.parse_term env c))
 
 let term_app3_ast
     (type env) (type term)
     (module Type : Tff_intf.S with type env = env and type T.t = term)
-    env name mk =
+    ?(check=(fun _ _ _ _ -> ())) env name mk =
   make_op3 (module Type) env name (fun ast (a, b, c) ->
+      check ast a b c;
       mk ast (Type.parse_term env a) (Type.parse_term env b) (Type.parse_term env c))
 
 
@@ -274,32 +282,36 @@ let term_app3_ast
 let ty_app4
     (type env) (type ty)
     (module Type : Tff_intf.S with type env = env and type Ty.t = ty)
-    env name mk =
-  make_op4 (module Type) env name (fun _ (a, b, c, d) ->
+    ?(check=(fun _ _ _ _ _ -> ())) env name mk =
+  make_op4 (module Type) env name (fun ast (a, b, c, d) ->
+      check ast a b c d;
       mk (Type.parse_ty env a) (Type.parse_ty env b)
         (Type.parse_ty env c) (Type.parse_ty env d))
 
 let ty_app4_ast
     (type env) (type ty)
     (module Type : Tff_intf.S with type env = env and type Ty.t = ty)
-    env name mk =
+    ?(check=(fun _ _ _ _ _ -> ())) env name mk =
   make_op4 (module Type) env name (fun ast (a, b, c, d) ->
+      check ast a b c d;
       mk ast (Type.parse_ty env a) (Type.parse_ty env b)
         (Type.parse_ty env c) (Type.parse_ty env d))
 
 let term_app4
     (type env) (type term)
     (module Type : Tff_intf.S with type env = env and type T.t = term)
-    env name mk =
-  make_op4 (module Type) env name (fun _ (a, b, c, d) ->
+    ?(check=(fun _ _ _ _ _ -> ())) env name mk =
+  make_op4 (module Type) env name (fun ast (a, b, c, d) ->
+      check ast a b c d;
       mk (Type.parse_term env a) (Type.parse_term env b)
         (Type.parse_term env c) (Type.parse_term env d))
 
 let term_app4_ast
     (type env) (type term)
     (module Type : Tff_intf.S with type env = env and type T.t = term)
-    env name mk =
+    ?(check=(fun _ _ _ _ _ -> ())) env name mk =
   make_op4 (module Type) env name (fun ast (a, b, c, d) ->
+      check ast a b c d;
       mk ast (Type.parse_term env a) (Type.parse_term env b)
         (Type.parse_term env c) (Type.parse_term env d))
 
@@ -309,15 +321,17 @@ let term_app4_ast
 let term_app_left
     (type env) (type term)
     (module Type : Tff_intf.S with type env = env and type T.t = term)
-    env name mk =
-  make_assoc (module Type) env name (fun _ l ->
+    ?(check=(fun _ _ -> ())) env name mk =
+  make_assoc (module Type) env name (fun ast l ->
+      check ast l;
       fold_left_assoc mk (List.map (Type.parse_term env) l))
 
 let term_app_left_ast
     (type env) (type term)
     (module Type : Tff_intf.S with type env = env and type T.t = term)
-    env name mk =
+    ?(check=(fun _ _ -> ())) env name mk =
   make_assoc (module Type) env name (fun ast l ->
+      check ast l;
       fold_left_assoc (mk ast) (List.map (Type.parse_term env) l))
 
 
@@ -326,15 +340,17 @@ let term_app_left_ast
 let term_app_right
     (type env) (type term)
     (module Type : Tff_intf.S with type env = env and type T.t = term)
-    env name mk =
-  make_assoc (module Type) env name (fun _ l ->
+    ?(check=(fun _ _ -> ())) env name mk =
+  make_assoc (module Type) env name (fun ast l ->
+      check ast l;
       fold_right_assoc mk (List.map (Type.parse_term env) l))
 
 let term_app_right_ast
     (type env) (type term)
     (module Type : Tff_intf.S with type env = env and type T.t = term)
-    env name mk =
+    ?(check=(fun _ _ -> ())) env name mk =
   make_assoc (module Type) env name (fun ast l ->
+      check ast l;
       fold_right_assoc (mk ast) (List.map (Type.parse_term env) l))
 
 
@@ -343,8 +359,9 @@ let term_app_right_ast
 let term_app_chain
     (type env) (type term)
     (module Type : Tff_intf.S with type env = env and type T.t = term)
-    env name mk =
-  make_chain (module Type) env name (fun _ l ->
+    ?(check=(fun _ _ -> ())) env name mk =
+  make_chain (module Type) env name (fun ast l ->
+      check ast l;
       let l' = List.map (Type.parse_term env) l in
       map_chain (module Type) mk l'
     )
@@ -352,8 +369,9 @@ let term_app_chain
 let term_app_chain_ast
     (type env) (type term)
     (module Type : Tff_intf.S with type env = env and type T.t = term)
-    env name mk =
+    ?(check=(fun _ _ -> ())) env name mk =
   make_chain (module Type) env name (fun ast l ->
+      check ast l;
       let l' = List.map (Type.parse_term env) l in
       map_chain (module Type) (mk ast) l'
     )

--- a/src/typecheck/base.mli
+++ b/src/typecheck/base.mli
@@ -119,127 +119,159 @@ val map_chain :
 
 val app0 :
   (module Tff_intf.S with type env = 'env) ->
+  ?check:(Dolmen.Term.t -> unit) ->
   'env -> string -> ('ret) ->
   (Dolmen.Term.t -> Dolmen.Term.t list -> 'ret)
 
 val app0_ast :
   (module Tff_intf.S with type env = 'env) ->
+  ?check:(Dolmen.Term.t -> unit) ->
   'env -> string -> (Dolmen.Term.t -> 'ret) ->
   (Dolmen.Term.t -> Dolmen.Term.t list -> 'ret)
 
 
 val ty_app1 :
   (module Tff_intf.S with type env = 'env and type Ty.t = 'ty) ->
+  ?check:(Dolmen.Term.t -> Dolmen.Term.t -> unit) ->
   'env -> string -> ('ty -> 'ty) ->
   (Dolmen.Term.t -> Dolmen.Term.t list -> 'ty)
 
 val ty_app1_ast :
   (module Tff_intf.S with type env = 'env and type Ty.t = 'ty) ->
+  ?check:(Dolmen.Term.t -> Dolmen.Term.t -> unit) ->
   'env -> string -> (Dolmen.Term.t -> 'ty -> 'ty) ->
   (Dolmen.Term.t -> Dolmen.Term.t list -> 'ty)
 
 val term_app1 :
   (module Tff_intf.S with type env = 'env and type T.t = 'term) ->
+  ?check:(Dolmen.Term.t -> Dolmen.Term.t -> unit) ->
   'env -> string -> ('term -> 'term) ->
   (Dolmen.Term.t -> Dolmen.Term.t list -> 'term)
 
 val term_app1_ast :
   (module Tff_intf.S with type env = 'env and type T.t = 'term) ->
+  ?check:(Dolmen.Term.t -> Dolmen.Term.t -> unit) ->
   'env -> string -> (Dolmen.Term.t -> 'term -> 'term) ->
   (Dolmen.Term.t -> Dolmen.Term.t list -> 'term)
 
 
 val ty_app2 :
   (module Tff_intf.S with type env = 'env and type Ty.t = 'ty) ->
+  ?check:(Dolmen.Term.t -> Dolmen.Term.t -> Dolmen.Term.t -> unit) ->
   'env -> string -> ('ty -> 'ty -> 'ty) ->
   (Dolmen.Term.t -> Dolmen.Term.t list -> 'ty)
 
 val ty_app2_ast :
   (module Tff_intf.S with type env = 'env and type Ty.t = 'ty) ->
+  ?check:(Dolmen.Term.t -> Dolmen.Term.t -> Dolmen.Term.t -> unit) ->
   'env -> string -> (Dolmen.Term.t -> 'ty -> 'ty -> 'ty) ->
   (Dolmen.Term.t -> Dolmen.Term.t list -> 'ty)
 
 val term_app2 :
   (module Tff_intf.S with type env = 'env and type T.t = 'term) ->
+  ?check:(Dolmen.Term.t -> Dolmen.Term.t -> Dolmen.Term.t -> unit) ->
   'env -> string -> ('term -> 'term -> 'term) ->
   (Dolmen.Term.t -> Dolmen.Term.t list -> 'term)
 
 val term_app2_ast :
   (module Tff_intf.S with type env = 'env and type T.t = 'term) ->
+  ?check:(Dolmen.Term.t -> Dolmen.Term.t -> Dolmen.Term.t -> unit) ->
   'env -> string -> (Dolmen.Term.t -> 'term -> 'term -> 'term) ->
   (Dolmen.Term.t -> Dolmen.Term.t list -> 'term)
 
 
 val ty_app3 :
   (module Tff_intf.S with type env = 'env and type Ty.t = 'ty) ->
+  ?check:(Dolmen.Term.t -> Dolmen.Term.t ->
+          Dolmen.Term.t -> Dolmen.Term.t -> unit) ->
   'env -> string -> ('ty -> 'ty -> 'ty -> 'ty) ->
   (Dolmen.Term.t -> Dolmen.Term.t list -> 'ty)
 
 val ty_app3_ast :
   (module Tff_intf.S with type env = 'env and type Ty.t = 'ty) ->
+  ?check:(Dolmen.Term.t -> Dolmen.Term.t ->
+          Dolmen.Term.t -> Dolmen.Term.t -> unit) ->
   'env -> string -> (Dolmen.Term.t -> 'ty -> 'ty -> 'ty -> 'ty) ->
   (Dolmen.Term.t -> Dolmen.Term.t list -> 'ty)
 
 val term_app3 :
   (module Tff_intf.S with type env = 'env and type T.t = 'term) ->
+  ?check:(Dolmen.Term.t -> Dolmen.Term.t ->
+          Dolmen.Term.t -> Dolmen.Term.t -> unit) ->
   'env -> string -> ('term -> 'term -> 'term -> 'term) ->
   (Dolmen.Term.t -> Dolmen.Term.t list -> 'term)
 
 val term_app3_ast :
   (module Tff_intf.S with type env = 'env and type T.t = 'term) ->
+  ?check:(Dolmen.Term.t -> Dolmen.Term.t ->
+          Dolmen.Term.t -> Dolmen.Term.t -> unit) ->
   'env -> string -> (Dolmen.Term.t -> 'term -> 'term -> 'term -> 'term) ->
   (Dolmen.Term.t -> Dolmen.Term.t list -> 'term)
 
 
 val ty_app4 :
   (module Tff_intf.S with type env = 'env and type Ty.t = 'ty) ->
+  ?check:(Dolmen.Term.t -> Dolmen.Term.t -> Dolmen.Term.t ->
+          Dolmen.Term.t -> Dolmen.Term.t -> unit) ->
   'env -> string -> ('ty -> 'ty -> 'ty -> 'ty -> 'ty) ->
   (Dolmen.Term.t -> Dolmen.Term.t list -> 'ty)
 
 val ty_app4_ast :
   (module Tff_intf.S with type env = 'env and type Ty.t = 'ty) ->
+  ?check:(Dolmen.Term.t -> Dolmen.Term.t -> Dolmen.Term.t ->
+          Dolmen.Term.t -> Dolmen.Term.t -> unit) ->
   'env -> string -> (Dolmen.Term.t -> 'ty -> 'ty -> 'ty -> 'ty -> 'ty) ->
   (Dolmen.Term.t -> Dolmen.Term.t list -> 'ty)
 
 val term_app4 :
   (module Tff_intf.S with type env = 'env and type T.t = 'term) ->
+  ?check:(Dolmen.Term.t -> Dolmen.Term.t -> Dolmen.Term.t ->
+          Dolmen.Term.t -> Dolmen.Term.t -> unit) ->
   'env -> string -> ('term -> 'term -> 'term -> 'term -> 'term) ->
   (Dolmen.Term.t -> Dolmen.Term.t list -> 'term)
 
 val term_app4_ast :
   (module Tff_intf.S with type env = 'env and type T.t = 'term) ->
+  ?check:(Dolmen.Term.t -> Dolmen.Term.t -> Dolmen.Term.t ->
+          Dolmen.Term.t -> Dolmen.Term.t -> unit) ->
   'env -> string -> (Dolmen.Term.t -> 'term -> 'term -> 'term -> 'term -> 'term) ->
   (Dolmen.Term.t -> Dolmen.Term.t list -> 'term)
 
 
 val term_app_left :
   (module Tff_intf.S with type env = 'env and type T.t = 'term) ->
+  ?check:(Dolmen.Term.t -> Dolmen.Term.t list -> unit) ->
   'env -> string -> ('term -> 'term -> 'term) ->
   (Dolmen.Term.t -> Dolmen.Term.t list -> 'term)
 
 val term_app_left_ast :
   (module Tff_intf.S with type env = 'env and type T.t = 'term) ->
+  ?check:(Dolmen.Term.t -> Dolmen.Term.t list -> unit) ->
   'env -> string -> (Dolmen.Term.t -> 'term -> 'term -> 'term) ->
   (Dolmen.Term.t -> Dolmen.Term.t list -> 'term)
 
 val term_app_right :
   (module Tff_intf.S with type env = 'env and type T.t = 'term) ->
+  ?check:(Dolmen.Term.t -> Dolmen.Term.t list -> unit) ->
   'env -> string -> ('term -> 'term -> 'term) ->
   (Dolmen.Term.t -> Dolmen.Term.t list -> 'term)
 
 val term_app_right_ast :
   (module Tff_intf.S with type env = 'env and type T.t = 'term) ->
+  ?check:(Dolmen.Term.t -> Dolmen.Term.t list -> unit) ->
   'env -> string -> (Dolmen.Term.t -> 'term -> 'term -> 'term) ->
   (Dolmen.Term.t -> Dolmen.Term.t list -> 'term)
 
 
 val term_app_chain :
   (module Tff_intf.S with type env = 'env and type T.t = 'term) ->
+  ?check:(Dolmen.Term.t -> Dolmen.Term.t list -> unit) ->
   'env -> string -> ('term -> 'term -> 'term) ->
   (Dolmen.Term.t -> Dolmen.Term.t list -> 'term)
 
 val term_app_chain_ast :
   (module Tff_intf.S with type env = 'env and type T.t = 'term) ->
+  ?check:(Dolmen.Term.t -> Dolmen.Term.t list -> unit) ->
   'env -> string -> (Dolmen.Term.t -> 'term -> 'term -> 'term) ->
   (Dolmen.Term.t -> Dolmen.Term.t list -> 'term)
 

--- a/src/typecheck/logic.mli
+++ b/src/typecheck/logic.mli
@@ -25,8 +25,7 @@ module Smtlib2 : sig
     free_functions  : bool;
     datatypes       : bool;
     quantifiers     : bool;
-    arithmetic      : [ `Linear_large | `Linear_strict
-                      | `Difference | `Regular ];
+    arithmetic      : Arith.Smtlib2.arith;
   }
   (** Smtlib features. *)
 

--- a/tests/typing/error-arith_linear/test.expected
+++ b/tests/typing/error-arith_linear/test.expected
@@ -1,6 +1,6 @@
 File "tests/typing/error-arith_linear/test.smt2", line 4, character 13-20:
 [1m[91mError[0;1m[0m Non-linear expressions are forbidden by the logic.
-      Hint: multiplication in linear arithmetic expects an integer or
+      Hint: multiplication in strict linear arithmetic expects an integer or
       rational literal and a symbol (variable or constant) but was given:
-      - the constant a
-      - the constant b
+      - a symbol (or quantified variable)
+      - a symbol (or quantified variable)


### PR DESCRIPTION
This shuffles around quite a lot of code to make it possible to implement the linearity, difference logic, and quantifier restrictions in the type-checker, rather than at the level of expressions.
This brings one major advantage, which is that linearity checks can now raise warnings in addition to errors, which makes it possible to treat some breaches of linearity/difference logic as warnings rather than errors when in `--strict=false` mode.
Additionally, it removes quite a lot of mutability and references that were used and which all had to be kept in the correct state.

Since the expression filters are not used anymore, I'm wondering whether we need to keep them or not; @bobot do you use (or plan to make use of) expression filters ?