### PR TITLE
error message for syntax

### DIFF
--- a/src/bin/errors.ml
+++ b/src/bin/errors.ml
@@ -69,8 +69,8 @@ let exn st = function
         (if l.Dolmen.Std.Loc.start_line = 1 &&
             l.Dolmen.Std.Loc.stop_line = 1 then prelude_space st else "")
         Dolmen.Std.Loc.fmt_hint l;
-    Loop.State.error ~loc: { file; loc; } st "%s@."
-      (match msg with "" -> "Syntax error" | x -> x)
+    Loop.State.error ~loc: { file; loc; } st "%a@."
+      Format.pp_print_text (match msg with "" -> "Syntax error" | x -> x)
 
 
   (* Typing errors *)

--- a/src/languages/smtlib2/v2.6/syntax.messages
+++ b/src/languages/smtlib2/v2.6/syntax.messages
@@ -348,7 +348,8 @@ term: OPEN MATCH SYMBOL OPEN OPEN OPEN SYMBOL UNDERSCORE
 ## OPEN pattern_symbol
 ##
 
-<YOUR SYNTAX ERROR MESSAGE HERE>
+'_' is not a valid pattern, but a reserved keyword. Patterns should be
+variables, nullary constructors, or n-ary constructor applications.
 
 term: OPEN MATCH SYMBOL OPEN OPEN OPEN UNDERSCORE
 ##

--- a/src/languages/smtlib2/v2.6/syntax.messages
+++ b/src/languages/smtlib2/v2.6/syntax.messages
@@ -348,7 +348,7 @@ term: OPEN MATCH SYMBOL OPEN OPEN OPEN SYMBOL UNDERSCORE
 ## OPEN pattern_symbol
 ##
 
-'_' is not a valid pattern, but a reserved keyword. Patterns should be
+"(_)" is not a valid pattern, but a reserved keyword. Patterns should be
 variables, nullary constructors, or n-ary constructor applications.
 
 term: OPEN MATCH SYMBOL OPEN OPEN OPEN UNDERSCORE
@@ -361,7 +361,8 @@ term: OPEN MATCH SYMBOL OPEN OPEN OPEN UNDERSCORE
 ## OPEN
 ##
 
-<YOUR SYNTAX ERROR MESSAGE HERE>
+'_' is not a valid pattern, but a reserved keyword. Patterns should be
+variables, nullary constructors, or n-ary constructor applications.
 
 term: OPEN MATCH SYMBOL OPEN OPEN SYMBOL SYMBOL CLOSE CLOSE UNDERSCORE
 ##
@@ -422,7 +423,8 @@ term: OPEN MATCH SYMBOL OPEN OPEN UNDERSCORE
 ## OPEN
 ##
 
-<YOUR SYNTAX ERROR MESSAGE HERE>
+'_' is not a valid pattern, but a reserved keyword. Patterns should be
+variables, nullary constructors, or n-ary constructor applications.
 
 term: OPEN MATCH SYMBOL OPEN UNDERSCORE
 ##
@@ -531,7 +533,8 @@ term: OPEN OPEN UNDERSCORE UNDERSCORE
 ## OPEN UNDERSCORE
 ##
 
-<YOUR SYNTAX ERROR MESSAGE HERE>
+'_' is not a valid pattern, but a reserved keyword. Patterns should be
+variables, nullary constructors, or n-ary constructor applications.
 
 term: OPEN STR
 ##

--- a/src/standard/transformer.ml
+++ b/src/standard/transformer.ml
@@ -66,7 +66,7 @@ module Make
     match String.trim (Ty.error s) with
     | exception Not_found -> ""
     | "<YOUR SYNTAX ERROR MESSAGE HERE>" -> ""
-    | msg -> msg
+    | msg -> String.map (function '\n' -> ' ' | c -> c) msg
 
 
   (* Parsing loop

--- a/tests/parsing/smtlib/v2.6/syntax_error.expected
+++ b/tests/parsing/smtlib/v2.6/syntax_error.expected
@@ -1,3 +1,4 @@
 [1m[97mFile "tests/parsing/smtlib/v2.6/syntax_error.smt2", line 3, character 41-42:
-[0;1m[0m[1m[91mError[0;1m[0m Syntax error
+[0;1m[0m[1m[91mError[0;1m[0m '_' is not a valid pattern, but a reserved keyword. Patterns should be
+variables, nullary constructors, or n-ary constructor applications.
 


### PR DESCRIPTION
can't figure out how to test it, now I get:

```sh
$ dolmen foo.smt2
File "", line 1, character 104-105:
Error Syntax error
```

which is weird, for input:

```
(set-logic ALL)
(declare-datatypes ((t 0)) (((A) (B) (C) (D))))
(define-fun f ((x t)) t (match x ((A B) (_ x))))
(check-sat)
```