### PR TITLE
Make files re-parsables

### DIFF
--- a/src/classes/logic.mli
+++ b/src/classes/logic.mli
@@ -5,6 +5,9 @@
 
 module type S = sig
 
+  type file
+  (** File location meta-data. *)
+
   type statement
   (** The type of statements. *)
 
@@ -45,14 +48,14 @@ module type S = sig
 
   val parse_file :
     ?language:language ->
-    string -> language * statement list
+    string -> language * file * statement list
   (** Given a filename, parse the file, and return the detected language
       together with the list of statements parsed.
       @param language specify a language; overrides auto-detection. *)
 
   val parse_file_lazy :
     ?language:language ->
-    string -> language * statement list Lazy.t
+    string -> language * file * statement list Lazy.t
   (** Given a filename, parse the file, and return the detected language
       together with the list of statements parsed.
       @param language specify a language; overrides auto-detection. *)
@@ -62,7 +65,7 @@ module type S = sig
     [< `File of string
     | `Stdin of language
     | `Raw of string * language * string ] ->
-    language * (unit -> statement option) * (unit -> unit)
+    language * file * (unit -> statement option) * (unit -> unit)
   (** Incremental parsing of either a file (see {!parse_file}), stdin
       (with given language), or some arbitrary contents, of the form
       [`Raw (filename, language, contents)].
@@ -74,7 +77,9 @@ module type S = sig
 
   (** {2 Mid-level parsing} *)
 
-  module type S = Dolmen_intf.Language.S with type statement := statement
+  module type S = Dolmen_intf.Language.S
+    with type statement := statement
+     and type file := file
   (** The type of language modules. *)
 
   val of_language   : language  -> language * string * (module S)
@@ -100,5 +105,5 @@ module Make
     (S : Dolmen_intf.Stmt.Logic with type location := L.t
                                  and type id := I.t
                                  and type term := T.t)
-  : S with type statement := S.t
+  : S with type statement := S.t and type file := L.file
 

--- a/src/interface/language.ml
+++ b/src/interface/language.ml
@@ -5,6 +5,9 @@
 
 module type S = sig
 
+  type file
+  (** Meta-data about locations in files. *)
+
   type token
   (** The type of tokens produced by the language lexer. *)
 
@@ -25,13 +28,17 @@ module type S = sig
       Separates directory and file because most include directives in languages
       are relative to the directory of the original file being processed. *)
 
-  val parse_file : string -> statement list
+  val parse_file : string -> file * statement list
+  (** Parse the given file.
+      @param dir: optional directory to use if the file path is relative. *)
+
+  val parse_file_lazy : string -> file * statement list Lazy.t
   (** Parse the given file.
       @param dir: optional directory to use if the file path is relative. *)
 
   val parse_input :
     [ `Stdin | `File of string | `Contents of string * string ] ->
-    (unit -> statement option) * (unit -> unit)
+    file * (unit -> statement option) * (unit -> unit)
   (** Incremental parsing. Given an input to read (either a file, stdin,
       or some contents of the form [(filename, s)] where [s] is the contents to parse),
       returns a generator that will incrementally parse the statements,

--- a/src/interface/location.ml
+++ b/src/interface/location.ml
@@ -14,6 +14,10 @@ module type S = sig
   type t
   (** The type of locations. *)
 
+  type file
+  (** A store for various meta-data about an input file,
+      can be used to optimize representation of locations. *)
+
   exception Uncaught of t * exn
   (** The exception to be raised whenever an unexpected exception is raised during parsing. *)
 
@@ -29,9 +33,12 @@ module type S = sig
   val mk_pos : Lexing.position -> Lexing.position -> t
   (** Make a position from two lewing positions. *)
 
-  val newline : string -> (Lexing.lexbuf -> unit)
-  (** A function first given the name of the file, and which should return a
-      closure that will be called on each new_line. *)
+  val mk_file : string -> file
+  (** Create meta-data for a given filename. *)
+
+  val newline : file -> Lexing.lexbuf -> unit
+  (** Offer a way for the file meta-data to store the current location
+      of the lexbuf as the start of a new line. *)
 
 end
 

--- a/src/languages/ae/dolmen_ae.mli
+++ b/src/languages/ae/dolmen_ae.mli
@@ -13,6 +13,6 @@ module Make
     (I : Id)
     (T : Term with type location := L.t and type id := I.t)
     (S : Statement with type location := L.t and type id := I.t and type term := T.t) :
-  Dolmen_intf.Language.S with type statement = S.t
+  Dolmen_intf.Language.S with type statement = S.t and type file := L.file
 (** Functor to generate a parser for the TPTP format. *)
 

--- a/src/languages/dimacs/dolmen_dimacs.mli
+++ b/src/languages/dimacs/dolmen_dimacs.mli
@@ -11,5 +11,5 @@ module Make
     (L : Dolmen_intf.Location.S)
     (T : Term with type location := L.t)
     (S : Statement with type location := L.t and type term := T.t) :
-  Dolmen_intf.Language.S with type statement = S.t
+  Dolmen_intf.Language.S with type statement = S.t and type file := L.file
 (** Functor to generate a parser for the dimacs format. *)

--- a/src/languages/icnf/dolmen_icnf.mli
+++ b/src/languages/icnf/dolmen_icnf.mli
@@ -11,5 +11,5 @@ module Make
     (L : Dolmen_intf.Location.S)
     (T : Term with type location := L.t)
     (S : Statement with type location := L.t and type term := T.t) :
-  Dolmen_intf.Language.S with type statement = S.t
+  Dolmen_intf.Language.S with type statement = S.t and type file := L.file
 (** Functor to generate a parser for the iCNF format. *)

--- a/src/languages/smtlib2/v2.6/dolmen_smtlib2_v6.mli
+++ b/src/languages/smtlib2/v2.6/dolmen_smtlib2_v6.mli
@@ -13,5 +13,5 @@ module Make
     (I : Id)
     (T : Term with type location := L.t and type id := I.t)
     (S : Statement with type location := L.t and type id := I.t and type term := T.t) :
-  Dolmen_intf.Language.S with type statement = S.t
+  Dolmen_intf.Language.S with type statement = S.t and type file := L.file
 (** Functor to generate a parser for the Smtlib format. *)

--- a/src/languages/tptp/v6.3.0/dolmen_tptp_v6_3_0.mli
+++ b/src/languages/tptp/v6.3.0/dolmen_tptp_v6_3_0.mli
@@ -13,6 +13,6 @@ module Make
     (I : Id)
     (T : Term with type location := L.t and type id := I.t)
     (S : Statement with type location := L.t and type id := I.t and type term := T.t) :
-  Dolmen_intf.Language.S with type statement = S.t
+  Dolmen_intf.Language.S with type statement = S.t and type file := L.file
 (** Functor to generate a parser for the TPTP format. *)
 

--- a/src/languages/zf/dolmen_zf.mli
+++ b/src/languages/zf/dolmen_zf.mli
@@ -13,6 +13,6 @@ module Make
     (I : Id)
     (T : Term with type location := L.t and type id := I.t)
     (S : Statement with type location := L.t and type id := I.t and type term := T.t) :
-  Dolmen_intf.Language.S with type statement = S.t
+  Dolmen_intf.Language.S with type statement = S.t and type file := L.file
 (** Functor to generate a parser for the Zipperposition format. *)
 

--- a/src/loop/logic.ml
+++ b/src/loop/logic.ml
@@ -10,4 +10,5 @@ module P = Dolmen.Class.Logic.Make
     (Dolmen.Std.Term)
     (Dolmen.Std.Statement)
 
-include (P : Dolmen.Class.Logic.S with type statement := Dolmen.Std.Statement.t)
+include (P : Dolmen.Class.Logic.S with type statement := Dolmen.Std.Statement.t
+                                   and type file := Dolmen.Std.Loc.file)

--- a/src/loop/logic.mli
+++ b/src/loop/logic.mli
@@ -4,4 +4,5 @@
 (** This is an instanciation of the Logic class with the standard
     implementation of parsed terms and statements of Dolmen. *)
 include Dolmen.Class.Logic.S with type statement := Dolmen.Std.Statement.t
+                              and type file := Dolmen.Std.Loc.file
 

--- a/src/standard/loc.ml
+++ b/src/standard/loc.ml
@@ -87,29 +87,21 @@ let mk_compact offset length =
 (* File table *)
 (* ************************************************************************* *)
 
-let tables = Hashtbl.create 5
-
 let file_name { name; _ } = name
 
 let mk_file name =
-  try Hashtbl.find tables name
-  with Not_found ->
-    let table = Vec.create () in
-    let () = Vec.push table (-1) in
-    let file = { name; table; } in
-    Hashtbl.add tables name file;
-    file
+  let table = Vec.create () in
+  let () = Vec.push table (-1) in
+  { name; table; }
 
 let new_line file offset =
   assert (Vec.last file.table < offset);
   Vec.push file.table (offset - 1)
 
-let newline filename =
-  let file = mk_file filename in
-  (fun lexbuf ->
-     Lexing.new_line lexbuf;
-     let offset = Lexing.lexeme_end lexbuf in
-     new_line file offset)
+let newline file lexbuf =
+  Lexing.new_line lexbuf;
+  let offset = Lexing.lexeme_end lexbuf in
+  new_line file offset
 
 let find_line file offset =
   let rec aux vec offset start stop =

--- a/src/standard/loc.mli
+++ b/src/standard/loc.mli
@@ -55,7 +55,7 @@ val is_dummy : loc -> bool
 (** {2 Compact location handling} *)
 
 val mk_file : string -> file
-(** Return the meta-data associated to a file. *)
+(** Create a new set of meta-data for the given filename. *)
 
 val new_line : file -> int -> unit
 (** Register a new line whose first char is at the given offset. *)

--- a/src/standard/loc.mli
+++ b/src/standard/loc.mli
@@ -36,7 +36,7 @@ module type S = Dolmen_intf.Location.S
 (** An anstract module type for providing locations. Used
     as argumentby much of the functors provided in Dolmen. *)
 
-include S with type t := t
+include S with type t := t and type file := file
 (** This module implements the signature {S}. *)
 
 val hash : t -> int


### PR DESCRIPTION
Remove the file loc table, and thread the loc file all the way, this makes it possible to re-parse the same file multliple times.

Fixes #54 