### PR TITLE
[Bitv] add the size of the bitvectors in the builtins

### DIFF
--- a/src/standard/builtin.ml
+++ b/src/standard/builtin.ml
@@ -78,25 +78,41 @@ type _ t +=
 type _ t +=
   | Bitv of int
   | Bitvec of string
-  | Bitv_concat of int * int
-  | Bitv_extract of int * int * int
-  | Bitv_repeat of int * int
-  | Bitv_zero_extend of int * int
-  | Bitv_sign_extend of int * int
-  | Bitv_rotate_right of int * int
-  | Bitv_rotate_left of int * int
-  | Bitv_not of int | Bitv_and of int | Bitv_or of int
-  | Bitv_nand of int | Bitv_nor of int
-  | Bitv_xor of int | Bitv_xnor of int
+  | Bitv_concat of { n : int; m : int }
+  | Bitv_extract of { n : int; i : int; j : int }
+  | Bitv_repeat of { n : int; k : int }
+  | Bitv_zero_extend of { n : int; k : int }
+  | Bitv_sign_extend of { n : int; k : int }
+  | Bitv_rotate_right of { n : int; i : int }
+  | Bitv_rotate_left of { n : int; i : int }
+  | Bitv_not of int
+  | Bitv_and of int
+  | Bitv_or of int
+  | Bitv_nand of int
+  | Bitv_nor of int
+  | Bitv_xor of int
+  | Bitv_xnor of int
   | Bitv_comp of int
-  | Bitv_neg of int | Bitv_add of int | Bitv_sub of int | Bitv_mul of int
-  | Bitv_udiv of int | Bitv_urem of int
-  | Bitv_sdiv of int | Bitv_srem of int | Bitv_smod of int
-  | Bitv_shl of int | Bitv_lshr of int | Bitv_ashr of int
-  | Bitv_ult of int | Bitv_ule of int
-  | Bitv_ugt of int | Bitv_uge of int
-  | Bitv_slt of int | Bitv_sle of int
-  | Bitv_sgt of int | Bitv_sge of int
+  | Bitv_neg of int
+  | Bitv_add of int
+  | Bitv_sub of int
+  | Bitv_mul of int
+  | Bitv_udiv of int
+  | Bitv_urem of int
+  | Bitv_sdiv of int
+  | Bitv_srem of int
+  | Bitv_smod of int
+  | Bitv_shl of int
+  | Bitv_lshr of int
+  | Bitv_ashr of int
+  | Bitv_ult of int
+  | Bitv_ule of int
+  | Bitv_ugt of int
+  | Bitv_uge of int
+  | Bitv_slt of int
+  | Bitv_sle of int
+  | Bitv_sgt of int
+  | Bitv_sge of int
 
 (* Floats *)
 type _ t +=

--- a/src/standard/builtin.ml
+++ b/src/standard/builtin.ml
@@ -78,25 +78,25 @@ type _ t +=
 type _ t +=
   | Bitv of int
   | Bitvec of string
-  | Bitv_concat
-  | Bitv_extract of int * int
-  | Bitv_repeat
-  | Bitv_zero_extend
-  | Bitv_sign_extend
-  | Bitv_rotate_right of int
-  | Bitv_rotate_left of int
-  | Bitv_not | Bitv_and | Bitv_or
-  | Bitv_nand | Bitv_nor
-  | Bitv_xor | Bitv_xnor
-  | Bitv_comp
-  | Bitv_neg | Bitv_add | Bitv_sub | Bitv_mul
-  | Bitv_udiv | Bitv_urem
-  | Bitv_sdiv | Bitv_srem | Bitv_smod
-  | Bitv_shl | Bitv_lshr | Bitv_ashr
-  | Bitv_ult | Bitv_ule
-  | Bitv_ugt | Bitv_uge
-  | Bitv_slt | Bitv_sle
-  | Bitv_sgt | Bitv_sge
+  | Bitv_concat of int * int
+  | Bitv_extract of int * int * int
+  | Bitv_repeat of int * int
+  | Bitv_zero_extend of int * int
+  | Bitv_sign_extend of int * int
+  | Bitv_rotate_right of int * int
+  | Bitv_rotate_left of int * int
+  | Bitv_not of int | Bitv_and of int | Bitv_or of int
+  | Bitv_nand of int | Bitv_nor of int
+  | Bitv_xor of int | Bitv_xnor of int
+  | Bitv_comp of int
+  | Bitv_neg of int | Bitv_add of int | Bitv_sub of int | Bitv_mul of int
+  | Bitv_udiv of int | Bitv_urem of int
+  | Bitv_sdiv of int | Bitv_srem of int | Bitv_smod of int
+  | Bitv_shl of int | Bitv_lshr of int | Bitv_ashr of int
+  | Bitv_ult of int | Bitv_ule of int
+  | Bitv_ugt of int | Bitv_uge of int
+  | Bitv_slt of int | Bitv_sle of int
+  | Bitv_sgt of int | Bitv_sge of int
 
 (* Floats *)
 type _ t +=

--- a/src/standard/builtin.mli
+++ b/src/standard/builtin.mli
@@ -322,27 +322,27 @@ type _ t +=
   (** [Bitvec s: Bitv]: bitvector litteral. The string [s] should
       be a binary representation of bitvectors using characters
       ['0'], and ['1'] (lsb last) *)
-  | Bitv_concat of int * int
+  | Bitv_concat of { n : int; m : int }
   (** [Bitv_concat(n,m): Bitv(n) -> Bitv(m) -> Bitv(n+m)]:
       concatenation operator on bitvectors. *)
-  | Bitv_extract of int * int * int
+  | Bitv_extract of { n : int; i : int; j : int }
   (** [Bitv_extract(n, i, j): Bitv(n) -> Bitv(i - j + 1)]:
       bitvector extraction, from index [j] up to [i] (both included). *)
-  | Bitv_repeat of int * int
-  (** [Bitv_repeat(n): Bitv(n) -> Bitv(n*k)]:
+  | Bitv_repeat of { n : int; k : int }
+  (** [Bitv_repeat(n,k): Bitv(n) -> Bitv(n*k)]:
       bitvector repeatition. *)
-  | Bitv_zero_extend of int * int
+  | Bitv_zero_extend of { n : int; k : int }
   (** [Bitv_zero_extend(n,k): Bitv(n) -> Bitv(n + k)]:
       zero extension for bitvectors (produces a representation of the
       same unsigned integer). *)
-  | Bitv_sign_extend of int * int
+  | Bitv_sign_extend of { n : int; k : int }
   (** [Bitv_sign_extend(n,k): Bitv(n) -> Bitv(n + k)]:
       sign extension for bitvectors ((produces a representation of the
       same signed integer). *)
-  | Bitv_rotate_right of int * int
+  | Bitv_rotate_right of { n : int; i : int }
   (** [Bitv_rotate_right(n,i): Bitv(n) -> Bitv(n)]:
       logical rotate right for bitvectors by [i]. *)
-  | Bitv_rotate_left of int * int
+  | Bitv_rotate_left of { n : int; i : int }
   (** [Bitv_rotate_left(n,i): Bitv(n) -> Bitv(n)]:
       logical rotate left for bitvectors by [i]. *)
   | Bitv_not of int
@@ -541,7 +541,7 @@ type _ t +=
   | To_sbv of int * int * int
   (** [To_ubv(s,e,m): RoundingMode -> Fp(s,e) -> Bitv(m)]: Convert to an signed integer *)
   | To_real of int * int
-  (** [To_real(s,e,m): RoundingMode -> Fp(s,e) -> Real]: Convert to real *)
+  (** [To_real(s,e): Fp(s,e) -> Real]: Convert to real *)
 
 
 (** {2 String and Regexp Builtins} *)

--- a/src/standard/builtin.mli
+++ b/src/standard/builtin.mli
@@ -322,125 +322,125 @@ type _ t +=
   (** [Bitvec s: Bitv]: bitvector litteral. The string [s] should
       be a binary representation of bitvectors using characters
       ['0'], and ['1'] (lsb last) *)
-  | Bitv_concat
-  (** [Bitv_concat: Bitv(n) -> Bitv(m) -> Bitv(n+m)]:
+  | Bitv_concat of int * int
+  (** [Bitv_concat(n,m): Bitv(n) -> Bitv(m) -> Bitv(n+m)]:
       concatenation operator on bitvectors. *)
-  | Bitv_extract of int * int
-  (** [Bitv_extract(i, j): Bitv(n) -> Bitv(i - j + 1)]:
+  | Bitv_extract of int * int * int
+  (** [Bitv_extract(n, i, j): Bitv(n) -> Bitv(i - j + 1)]:
       bitvector extraction, from index [j] up to [i] (both included). *)
-  | Bitv_repeat
-  (** [Bitv_repeat: Bitv(n) -> Bitv(n*k)]:
-      bitvector repeatition. NOTE: inlcude [k] in the builtin ? *)
-  | Bitv_zero_extend
-  (** [Bitv_zero_extend: Bitv(n) -> Bitv(n + k)]:
+  | Bitv_repeat of int * int
+  (** [Bitv_repeat(n): Bitv(n) -> Bitv(n*k)]:
+      bitvector repeatition. *)
+  | Bitv_zero_extend of int * int
+  (** [Bitv_zero_extend(n,k): Bitv(n) -> Bitv(n + k)]:
       zero extension for bitvectors (produces a representation of the
       same unsigned integer). *)
-  | Bitv_sign_extend
-  (** [Bitv_sign_extend: Bitv(n) -> Bitv(n + k)]:
+  | Bitv_sign_extend of int * int
+  (** [Bitv_sign_extend(n,k): Bitv(n) -> Bitv(n + k)]:
       sign extension for bitvectors ((produces a representation of the
       same signed integer). *)
-  | Bitv_rotate_right of int
-  (** [Bitv_rotate_right(i): Bitv(n) -> Bitv(n)]:
+  | Bitv_rotate_right of int * int
+  (** [Bitv_rotate_right(n,i): Bitv(n) -> Bitv(n)]:
       logical rotate right for bitvectors by [i]. *)
-  | Bitv_rotate_left of int
-  (** [Bitv_rotate_left(i): Bitv(n) -> Bitv(n)]:
+  | Bitv_rotate_left of int * int
+  (** [Bitv_rotate_left(n,i): Bitv(n) -> Bitv(n)]:
       logical rotate left for bitvectors by [i]. *)
-  | Bitv_not
-  (** [Bitv_not: Bitv(n) -> Bitv(n)]:
+  | Bitv_not of int
+  (** [Bitv_not(n): Bitv(n) -> Bitv(n)]:
       bitwise negation for bitvectors. *)
-  | Bitv_and
-  (** [Bitv_and: Bitv(n) -> Bitv(n) -> Bitv(n)]:
+  | Bitv_and of int
+  (** [Bitv_and(n): Bitv(n) -> Bitv(n) -> Bitv(n)]:
       bitwise conjunction for bitvectors. *)
-  | Bitv_or
-  (** [bitv_or: Bitv(n) -> Bitv(n) -> Bitv(n)]:
+  | Bitv_or of int
+  (** [bitv_or(n): Bitv(n) -> Bitv(n) -> Bitv(n)]:
       bitwise disjunction for bitvectors. *)
-  | Bitv_nand
-  (** [Bitv_nand: Bitv(n) -> Bitv(n) -> Bitv(n)]:
+  | Bitv_nand of int
+  (** [Bitv_nand(n): Bitv(n) -> Bitv(n) -> Bitv(n)]:
       bitwise negated conjunction for bitvectors.
       [Bitv_nand s t] abbreviates [Bitv_not (Bitv_and s t))]. *)
-  | Bitv_nor
-  (** [Bitv_nor: Bitv(n) -> Bitv(n) -> Bitv(n)]:
+  | Bitv_nor of int
+  (** [Bitv_nor(n): Bitv(n) -> Bitv(n) -> Bitv(n)]:
       bitwise negated disjunction for bitvectors.
       [Bitv_nor s t] abbreviates [Bitv_not (Bitv_or s t))]. *)
-  | Bitv_xor
-  (** [Bitv_xor: Bitv(n) -> Bitv(n) -> Bitv(n)]:
+  | Bitv_xor of int
+  (** [Bitv_xor(n): Bitv(n) -> Bitv(n) -> Bitv(n)]:
       bitwise exclusive disjunction for bitvectors.
       [Bitv_xor s t] abbreviates
       [Bitv_or (Bitv_and s (Bitv_not t))
                (Bitv_and (Bitv_not s) t) ]. *)
-  | Bitv_xnor
-  (** [Bitv_xnor: Bitv(n) -> Bitv(n) -> Bitv(n)]:
+  | Bitv_xnor of int
+  (** [Bitv_xnor(n): Bitv(n) -> Bitv(n) -> Bitv(n)]:
       bitwise negated exclusive disjunction for bitvectors.
       [Bitv_xnor s t] abbreviates
       [Bitv_or (Bitv_and s t)
                (Bitv_and (Bitv_not s) (Bitv_not t))]. *)
-  | Bitv_comp
-  (** [Bitv_comp: Bitv(n) -> Bitv(n) -> Bitv(1)]:
+  | Bitv_comp of int
+  (** [Bitv_comp(n): Bitv(n) -> Bitv(n) -> Bitv(1)]:
       Returns the constant bitvector ["1"] is all bits are equal,
       and the bitvector ["0"] if not. *)
-  | Bitv_neg
-  (** [Bitv_neg: Bitv(n) -> Bitv(n)]:
+  | Bitv_neg of int
+  (** [Bitv_neg(n): Bitv(n) -> Bitv(n)]:
       2's complement unary minus. *)
-  | Bitv_add
-  (** [Bitv_add: Bitv(n) -> Bitv(n) -> Bitv(n)]:
+  | Bitv_add of int
+  (** [Bitv_add(n): Bitv(n) -> Bitv(n) -> Bitv(n)]:
       addition modulo 2^n. *)
-  | Bitv_sub
-  (** [Bitv_sub: Bitv(n) -> Bitv(n) -> Bitv(n)]:
+  | Bitv_sub of int
+  (** [Bitv_sub(n): Bitv(n) -> Bitv(n) -> Bitv(n)]:
       2's complement subtraction modulo 2^n. *)
-  | Bitv_mul
-  (** [Bitv_mul: Bitv(n) -> Bitv(n) -> Bitv(n)]:
+  | Bitv_mul of int
+  (** [Bitv_mul(n): Bitv(n) -> Bitv(n) -> Bitv(n)]:
       multiplication modulo 2^n. *)
-  | Bitv_udiv
-  (** [Bitv_udiv: Bitv(n) -> Bitv(n) -> Bitv(n)]:
+  | Bitv_udiv of int
+  (** [Bitv_udiv(n): Bitv(n) -> Bitv(n) -> Bitv(n)]:
       unsigned division, truncating towards 0. *)
-  | Bitv_urem
-  (** [Bitv_urem: Bitv(n) -> Bitv(n) -> Bitv(n)]:
+  | Bitv_urem of int
+  (** [Bitv_urem(n): Bitv(n) -> Bitv(n) -> Bitv(n)]:
       unsigned remainder from truncating division. *)
-  | Bitv_sdiv
-  (** [Bitv_sdiv: Bitv(n) -> Bitv(n) -> Bitv(n)]:
+  | Bitv_sdiv of int
+  (** [Bitv_sdiv(n): Bitv(n) -> Bitv(n) -> Bitv(n)]:
       2's complement signed division. *)
-  | Bitv_srem
-  (** [Bitv_srem: Bitv(n) -> Bitv(n) -> Bitv(n)]:
+  | Bitv_srem of int
+  (** [Bitv_srem(n): Bitv(n) -> Bitv(n) -> Bitv(n)]:
       2's complement signed remainder (sign follows dividend). *)
-  | Bitv_smod
-  (** [Bitv_smod: Bitv(n) -> Bitv(n) -> Bitv(n)]:
+  | Bitv_smod of int
+  (** [Bitv_smod(n): Bitv(n) -> Bitv(n) -> Bitv(n)]:
       2's complement signed remainder (sign follows divisor). *)
-  | Bitv_shl
-  (** [Bitv_shl: Bitv(n) -> Bitv(n) -> Bitv(n)]:
+  | Bitv_shl of int
+  (** [Bitv_shl(n): Bitv(n) -> Bitv(n) -> Bitv(n)]:
       shift left (equivalent to multiplication by 2^x where x
       is the value of the second argument). *)
-  | Bitv_lshr
-  (** [Bitv_lshr: Bitv(n) -> Bitv(n) -> Bitv(n)]:
+  | Bitv_lshr of int
+  (** [Bitv_lshr(n): Bitv(n) -> Bitv(n) -> Bitv(n)]:
       logical shift right (equivalent to unsigned division by 2^x,
       where x is the value of the second argument). *)
-  | Bitv_ashr
-  (** [Bitv_ashr: Bitv(n) -> Bitv(n) -> Bitv(n)]:
+  | Bitv_ashr of int
+  (** [Bitv_ashr(n): Bitv(n) -> Bitv(n) -> Bitv(n)]:
       Arithmetic shift right, like logical shift right except that
       the most significant bits of the result always copy the most
       significant bit of the first argument. *)
-  | Bitv_ult
-  (** [Bitv_ult: Bitv(n) -> Bitv(n) -> Prop]:
+  | Bitv_ult of int
+  (** [Bitv_ult(n): Bitv(n) -> Bitv(n) -> Prop]:
       binary predicate for unsigned less-than. *)
-  | Bitv_ule
-  (** [Bitv_ule: Bitv(n) -> Bitv(n) -> Prop]:
+  | Bitv_ule of int
+  (** [Bitv_ule(n): Bitv(n) -> Bitv(n) -> Prop]:
       binary predicate for unsigned less than or equal. *)
-  | Bitv_ugt
-  (** [Bitv_ugt: Bitv(n) -> Bitv(n) -> Prop]:
+  | Bitv_ugt of int
+  (** [Bitv_ugt(n): Bitv(n) -> Bitv(n) -> Prop]:
       binary predicate for unsigned greater-than. *)
-  | Bitv_uge
-  (** [Bitv_uge: Bitv(n) -> Bitv(n) -> Prop]:
+  | Bitv_uge of int
+  (** [Bitv_uge(n): Bitv(n) -> Bitv(n) -> Prop]:
       binary predicate for unsigned greater than or equal. *)
-  | Bitv_slt
-  (** [Bitv_slt: Bitv(n) -> Bitv(n) -> Prop]:
+  | Bitv_slt of int
+  (** [Bitv_slt(n): Bitv(n) -> Bitv(n) -> Prop]:
       binary predicate for signed less-than. *)
-  | Bitv_sle
-  (** [Bitv_sle: Bitv(n) -> Bitv(n) -> Prop]:
+  | Bitv_sle of int
+  (** [Bitv_sle(n): Bitv(n) -> Bitv(n) -> Prop]:
       binary predicate for signed less than or equal. *)
-  | Bitv_sgt
-  (** [Bitv_sgt: Bitv(n) -> Bitv(n) -> Prop]:
+  | Bitv_sgt of int
+  (** [Bitv_sgt(n): Bitv(n) -> Bitv(n) -> Prop]:
       binary predicate for signed greater-than. *)
-  | Bitv_sge
-  (** [Bitv_sge: Bitv(n) -> Bitv(n) -> Prop]:
+  | Bitv_sge of int
+  (** [Bitv_sge(n): Bitv(n) -> Bitv(n) -> Prop]:
       binary predicate for signed greater than or equal. *)
 
 

--- a/src/standard/expr.ml
+++ b/src/standard/expr.ml
@@ -1856,46 +1856,46 @@ module Term = struct
           (Format.asprintf "bv#%s#" s) [] [] (Ty.bitv (String.length s))
 
       let concat =
-        with_cache ~cache:(Hashtbl.create 13) (fun (i, j) ->
-            mk' ~builtin:(Builtin.Bitv_concat(i,j)) "bitv_concat"
-              [] [Ty.bitv i; Ty.bitv j] (Ty.bitv (i + j))
+        with_cache ~cache:(Hashtbl.create 13) (fun (n, m) ->
+            mk' ~builtin:(Builtin.Bitv_concat{n;m}) "bitv_concat"
+              [] [Ty.bitv n; Ty.bitv m] (Ty.bitv (n + m))
           )
 
       let extract =
         with_cache ~cache:(Hashtbl.create 13) (fun (i, j, n) ->
-            mk' ~builtin:(Builtin.Bitv_extract (n, i, j))
+            mk' ~builtin:(Builtin.Bitv_extract {n; i; j})
               (Format.asprintf "bitv_extract_%d_%d" i j) []
               [Ty.bitv n] (Ty.bitv (i - j + 1))
           )
 
       let repeat =
         with_cache ~cache:(Hashtbl.create 13) (fun (k, n) ->
-            mk' ~builtin:(Builtin.Bitv_repeat(n,k)) (Format.asprintf "bitv_repeat_%d" k)
+            mk' ~builtin:(Builtin.Bitv_repeat{n;k}) (Format.asprintf "bitv_repeat_%d" k)
               [] [Ty.bitv n] (Ty.bitv (n * k))
           )
 
       let zero_extend =
         with_cache ~cache:(Hashtbl.create 13) (fun (k, n) ->
-            mk' ~builtin:(Builtin.Bitv_zero_extend(n,k)) (Format.asprintf "zero_extend_%d" k)
+            mk' ~builtin:(Builtin.Bitv_zero_extend{n;k}) (Format.asprintf "zero_extend_%d" k)
               [] [Ty.bitv n] (Ty.bitv (n + k))
           )
 
       let sign_extend =
         with_cache ~cache:(Hashtbl.create 13) (fun (k, n) ->
-            mk' ~builtin:(Builtin.Bitv_sign_extend(n,k)) (Format.asprintf "sign_extend_%d" k)
+            mk' ~builtin:(Builtin.Bitv_sign_extend{n;k}) (Format.asprintf "sign_extend_%d" k)
               [] [Ty.bitv n] (Ty.bitv (n + k))
           )
 
       let rotate_right =
-        with_cache ~cache:(Hashtbl.create 13) (fun (k, n) ->
-            mk' ~builtin:(Builtin.Bitv_rotate_right (n,k))
-              (Format.asprintf "rotate_right_%d" k) [] [Ty.bitv n] (Ty.bitv n)
+        with_cache ~cache:(Hashtbl.create 13) (fun (i, n) ->
+            mk' ~builtin:(Builtin.Bitv_rotate_right{n;i})
+              (Format.asprintf "rotate_right_%d" i) [] [Ty.bitv n] (Ty.bitv n)
           )
 
       let rotate_left =
-        with_cache ~cache:(Hashtbl.create 13) (fun (k, n) ->
-            mk' ~builtin:(Builtin.Bitv_rotate_left(n,k))
-              (Format.asprintf "rotate_left_%d" k) [] [Ty.bitv n] (Ty.bitv n)
+        with_cache ~cache:(Hashtbl.create 13) (fun (i, n) ->
+            mk' ~builtin:(Builtin.Bitv_rotate_left{n;i})
+              (Format.asprintf "rotate_left_%d" i) [] [Ty.bitv n] (Ty.bitv n)
           )
 
       let not =

--- a/src/standard/expr.ml
+++ b/src/standard/expr.ml
@@ -1857,192 +1857,192 @@ module Term = struct
 
       let concat =
         with_cache ~cache:(Hashtbl.create 13) (fun (i, j) ->
-            mk' ~builtin:Builtin.Bitv_concat "bitv_concat"
+            mk' ~builtin:(Builtin.Bitv_concat(i,j)) "bitv_concat"
               [] [Ty.bitv i; Ty.bitv j] (Ty.bitv (i + j))
           )
 
       let extract =
         with_cache ~cache:(Hashtbl.create 13) (fun (i, j, n) ->
-            mk' ~builtin:(Builtin.Bitv_extract (i, j))
+            mk' ~builtin:(Builtin.Bitv_extract (n, i, j))
               (Format.asprintf "bitv_extract_%d_%d" i j) []
               [Ty.bitv n] (Ty.bitv (i - j + 1))
           )
 
       let repeat =
         with_cache ~cache:(Hashtbl.create 13) (fun (k, n) ->
-            mk' ~builtin:Builtin.Bitv_repeat (Format.asprintf "bitv_repeat_%d" k)
+            mk' ~builtin:(Builtin.Bitv_repeat(n,k)) (Format.asprintf "bitv_repeat_%d" k)
               [] [Ty.bitv n] (Ty.bitv (n * k))
           )
 
       let zero_extend =
         with_cache ~cache:(Hashtbl.create 13) (fun (k, n) ->
-            mk' ~builtin:Builtin.Bitv_zero_extend (Format.asprintf "zero_extend_%d" k)
+            mk' ~builtin:(Builtin.Bitv_zero_extend(n,k)) (Format.asprintf "zero_extend_%d" k)
               [] [Ty.bitv n] (Ty.bitv (n + k))
           )
 
       let sign_extend =
         with_cache ~cache:(Hashtbl.create 13) (fun (k, n) ->
-            mk' ~builtin:Builtin.Bitv_sign_extend (Format.asprintf "sign_extend_%d" k)
+            mk' ~builtin:(Builtin.Bitv_sign_extend(n,k)) (Format.asprintf "sign_extend_%d" k)
               [] [Ty.bitv n] (Ty.bitv (n + k))
           )
 
       let rotate_right =
         with_cache ~cache:(Hashtbl.create 13) (fun (k, n) ->
-            mk' ~builtin:(Builtin.Bitv_rotate_right k)
+            mk' ~builtin:(Builtin.Bitv_rotate_right (n,k))
               (Format.asprintf "rotate_right_%d" k) [] [Ty.bitv n] (Ty.bitv n)
           )
 
       let rotate_left =
         with_cache ~cache:(Hashtbl.create 13) (fun (k, n) ->
-            mk' ~builtin:(Builtin.Bitv_rotate_left k)
+            mk' ~builtin:(Builtin.Bitv_rotate_left(n,k))
               (Format.asprintf "rotate_left_%d" k) [] [Ty.bitv n] (Ty.bitv n)
           )
 
       let not =
         with_cache ~cache:(Hashtbl.create 13) (fun n ->
-            mk' ~builtin:Builtin.Bitv_not "bvnot" [] [Ty.bitv n] (Ty.bitv n)
+            mk' ~builtin:(Builtin.Bitv_not n) "bvnot" [] [Ty.bitv n] (Ty.bitv n)
           )
 
       let and_ =
         with_cache ~cache:(Hashtbl.create 13) (fun n ->
-            mk' ~builtin:Builtin.Bitv_and "bvand" []
+            mk' ~builtin:(Builtin.Bitv_and n) "bvand" []
               [Ty.bitv n; Ty.bitv n] (Ty.bitv n)
           )
 
       let or_ =
         with_cache ~cache:(Hashtbl.create 13) (fun n ->
-            mk' ~builtin:Builtin.Bitv_or "bvor" []
+            mk' ~builtin:(Builtin.Bitv_or n) "bvor" []
               [Ty.bitv n; Ty.bitv n] (Ty.bitv n)
           )
 
       let nand =
         with_cache ~cache:(Hashtbl.create 13) (fun n ->
-            mk' ~builtin:Builtin.Bitv_nand "bvnand" []
+            mk' ~builtin:(Builtin.Bitv_nand n) "bvnand" []
               [Ty.bitv n; Ty.bitv n] (Ty.bitv n)
           )
 
       let nor =
         with_cache ~cache:(Hashtbl.create 13) (fun n ->
-            mk' ~builtin:Builtin.Bitv_nor "bvnor" []
+            mk' ~builtin:(Builtin.Bitv_nor n) "bvnor" []
               [Ty.bitv n; Ty.bitv n] (Ty.bitv n)
           )
 
       let xor =
         with_cache ~cache:(Hashtbl.create 13) (fun n ->
-            mk' ~builtin:Builtin.Bitv_xor "bvxor" []
+            mk' ~builtin:(Builtin.Bitv_xor n) "bvxor" []
               [Ty.bitv n; Ty.bitv n] (Ty.bitv n)
           )
 
       let xnor =
         with_cache ~cache:(Hashtbl.create 13) (fun n ->
-            mk' ~builtin:Builtin.Bitv_xnor "bvxnor" []
+            mk' ~builtin:(Builtin.Bitv_xnor n) "bvxnor" []
               [Ty.bitv n; Ty.bitv n] (Ty.bitv n)
           )
 
       let comp =
         with_cache ~cache:(Hashtbl.create 13) (fun n ->
-            mk' ~builtin:Builtin.Bitv_comp "bvcomp" []
+            mk' ~builtin:(Builtin.Bitv_comp n) "bvcomp" []
               [Ty.bitv n; Ty.bitv n] (Ty.bitv 1)
           )
 
       let neg =
         with_cache ~cache:(Hashtbl.create 13) (fun n ->
-            mk' ~builtin:Builtin.Bitv_neg "bvneg" [] [Ty.bitv n] (Ty.bitv n)
+            mk' ~builtin:(Builtin.Bitv_neg n) "bvneg" [] [Ty.bitv n] (Ty.bitv n)
           )
 
       let add =
         with_cache ~cache:(Hashtbl.create 13) (fun n ->
-            mk' ~builtin:Builtin.Bitv_add "bvadd" [] [Ty.bitv n; Ty.bitv n] (Ty.bitv n)
+            mk' ~builtin:(Builtin.Bitv_add n) "bvadd" [] [Ty.bitv n; Ty.bitv n] (Ty.bitv n)
           )
 
       let sub =
       with_cache ~cache:(Hashtbl.create 13) (fun n ->
-          mk' ~builtin:Builtin.Bitv_sub "bvsub" [] [Ty.bitv n; Ty.bitv n] (Ty.bitv n)
+          mk' ~builtin:(Builtin.Bitv_sub n) "bvsub" [] [Ty.bitv n; Ty.bitv n] (Ty.bitv n)
         )
 
       let mul =
         with_cache ~cache:(Hashtbl.create 13) (fun n ->
-            mk' ~builtin:Builtin.Bitv_mul "bvmul" [] [Ty.bitv n; Ty.bitv n] (Ty.bitv n)
+            mk' ~builtin:(Builtin.Bitv_mul n) "bvmul" [] [Ty.bitv n; Ty.bitv n] (Ty.bitv n)
           )
 
       let udiv =
         with_cache ~cache:(Hashtbl.create 13) (fun n ->
-            mk' ~builtin:Builtin.Bitv_udiv "bvudiv" [] [Ty.bitv n; Ty.bitv n] (Ty.bitv n)
+            mk' ~builtin:(Builtin.Bitv_udiv n) "bvudiv" [] [Ty.bitv n; Ty.bitv n] (Ty.bitv n)
           )
 
       let urem =
         with_cache ~cache:(Hashtbl.create 13) (fun n ->
-            mk' ~builtin:Builtin.Bitv_urem "bvurem" [] [Ty.bitv n; Ty.bitv n] (Ty.bitv n)
+            mk' ~builtin:(Builtin.Bitv_urem n) "bvurem" [] [Ty.bitv n; Ty.bitv n] (Ty.bitv n)
           )
 
       let sdiv =
         with_cache ~cache:(Hashtbl.create 13) (fun n ->
-            mk' ~builtin:Builtin.Bitv_sdiv "bvsdiv" [] [Ty.bitv n; Ty.bitv n] (Ty.bitv n)
+            mk' ~builtin:(Builtin.Bitv_sdiv n) "bvsdiv" [] [Ty.bitv n; Ty.bitv n] (Ty.bitv n)
           )
 
       let srem =
         with_cache ~cache:(Hashtbl.create 13) (fun n ->
-            mk' ~builtin:Builtin.Bitv_srem "bvsrem" [] [Ty.bitv n; Ty.bitv n] (Ty.bitv n)
+            mk' ~builtin:(Builtin.Bitv_srem n) "bvsrem" [] [Ty.bitv n; Ty.bitv n] (Ty.bitv n)
           )
 
       let smod =
         with_cache ~cache:(Hashtbl.create 13) (fun n ->
-            mk' ~builtin:Builtin.Bitv_smod "bvsmod" [] [Ty.bitv n; Ty.bitv n] (Ty.bitv n)
+            mk' ~builtin:(Builtin.Bitv_smod n) "bvsmod" [] [Ty.bitv n; Ty.bitv n] (Ty.bitv n)
           )
 
       let shl =
         with_cache ~cache:(Hashtbl.create 13) (fun n ->
-            mk' ~builtin:Builtin.Bitv_shl "bvshl" [] [Ty.bitv n; Ty.bitv n] (Ty.bitv n)
+            mk' ~builtin:(Builtin.Bitv_shl n) "bvshl" [] [Ty.bitv n; Ty.bitv n] (Ty.bitv n)
           )
 
       let lshr =
         with_cache ~cache:(Hashtbl.create 13) (fun n ->
-            mk' ~builtin:Builtin.Bitv_lshr "bvlshr" [] [Ty.bitv n; Ty.bitv n] (Ty.bitv n)
+            mk' ~builtin:(Builtin.Bitv_lshr n) "bvlshr" [] [Ty.bitv n; Ty.bitv n] (Ty.bitv n)
           )
 
       let ashr =
         with_cache ~cache:(Hashtbl.create 13) (fun n ->
-            mk' ~builtin:Builtin.Bitv_ashr "bvashr" [] [Ty.bitv n; Ty.bitv n] (Ty.bitv n)
+            mk' ~builtin:(Builtin.Bitv_ashr n) "bvashr" [] [Ty.bitv n; Ty.bitv n] (Ty.bitv n)
           )
 
       let ult =
         with_cache ~cache:(Hashtbl.create 13) (fun n ->
-            mk' ~builtin:Builtin.Bitv_ult "bvult" [] [Ty.bitv n; Ty.bitv n] Ty.prop
+            mk' ~builtin:(Builtin.Bitv_ult n) "bvult" [] [Ty.bitv n; Ty.bitv n] Ty.prop
           )
 
       let ule =
         with_cache ~cache:(Hashtbl.create 13) (fun n ->
-            mk' ~builtin:Builtin.Bitv_ule "bvule" [] [Ty.bitv n; Ty.bitv n] Ty.prop
+            mk' ~builtin:(Builtin.Bitv_ule n) "bvule" [] [Ty.bitv n; Ty.bitv n] Ty.prop
           )
 
       let ugt =
         with_cache ~cache:(Hashtbl.create 13) (fun n ->
-            mk' ~builtin:Builtin.Bitv_ugt "bvugt" [] [Ty.bitv n; Ty.bitv n] Ty.prop
+            mk' ~builtin:(Builtin.Bitv_ugt n) "bvugt" [] [Ty.bitv n; Ty.bitv n] Ty.prop
           )
 
       let uge =
         with_cache ~cache:(Hashtbl.create 13) (fun n ->
-            mk' ~builtin:Builtin.Bitv_uge "bvsge" [] [Ty.bitv n; Ty.bitv n] Ty.prop
+            mk' ~builtin:(Builtin.Bitv_uge n) "bvsge" [] [Ty.bitv n; Ty.bitv n] Ty.prop
           )
 
       let slt =
         with_cache ~cache:(Hashtbl.create 13) (fun n ->
-            mk' ~builtin:Builtin.Bitv_slt "bvslt" [] [Ty.bitv n; Ty.bitv n] Ty.prop
+            mk' ~builtin:(Builtin.Bitv_slt n) "bvslt" [] [Ty.bitv n; Ty.bitv n] Ty.prop
           )
 
       let sle =
         with_cache ~cache:(Hashtbl.create 13) (fun n ->
-            mk' ~builtin:Builtin.Bitv_sle "bvsle" [] [Ty.bitv n; Ty.bitv n] Ty.prop
+            mk' ~builtin:(Builtin.Bitv_sle n) "bvsle" [] [Ty.bitv n; Ty.bitv n] Ty.prop
           )
 
       let sgt =
         with_cache ~cache:(Hashtbl.create 13) (fun n ->
-            mk' ~builtin:Builtin.Bitv_sgt "bvsgt" [] [Ty.bitv n; Ty.bitv n] Ty.prop
+            mk' ~builtin:(Builtin.Bitv_sgt n) "bvsgt" [] [Ty.bitv n; Ty.bitv n] Ty.prop
           )
 
       let sge =
         with_cache ~cache:(Hashtbl.create 13) (fun n ->
-            mk' ~builtin:Builtin.Bitv_sge "bvsge" [] [Ty.bitv n; Ty.bitv n] Ty.prop
+            mk' ~builtin:(Builtin.Bitv_sge n) "bvsge" [] [Ty.bitv n; Ty.bitv n] Ty.prop
           )
 
     end


### PR DESCRIPTION
It simplifies the matching and handling of the builtins of the bitvectors to have directly the size of the bitvectors. 