### PR TITLE
Fix windows build and tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,6 @@
 # Buildability check
 # ==================
-# Build dolmen with the makefile
+# Build dolmen using various version of the OCaml compiler
 name: build
 
 # Configure when to run the workflows. Currently only when
@@ -31,11 +31,8 @@ jobs:
 
       matrix:
         # Operating system to run tests on.
-        # TODO: add macos-latest and windows-latest
         os:
           - ubuntu-latest
-          #- macos-latest
-          #- windows-latest
 
         # Ocaml versions to test. This is a bit of a misnomer, considering
         # that it is actually just a list of package to install as the base

--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -40,9 +40,9 @@ jobs:
 
         # Ocaml versions to use
         # Also test flambda to make sure the installation time is reasonable
-        ocaml-version:
+        ocaml-compiler:
+          - 4.14.0
           - ocaml-variants.4.14.0+options,ocaml-option-flambda
-          - ocaml-base-compiler.4.14.0
 
         # Dolmen package to test installation of
         dolmen-pkg:
@@ -71,6 +71,9 @@ jobs:
     # Run opam udpate to get an up-to-date repo
     - name: Update opam repo
       run: opam update
+    # Debug
+    - name: Debugging
+      run: opam switch list-available
     # Install the package
     - name: Install package
       run: opam install --with-test ${{ matrix.dolmen-pkg }}

--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -1,6 +1,7 @@
 # Installability tests
 # ====================
-# Check the binary package install correctly
+# Check the binary package install correctly on all supported
+# platforms (and run the tests)
 name: install
 
 # Configure when to run the workflows. Currently only when
@@ -35,7 +36,7 @@ jobs:
         os:
           - ubuntu-latest
           - macos-latest
-          #- windows-latest
+          - windows-latest
 
         # Ocaml versions to use
         # Also test flambda to make sure the installation time is reasonable
@@ -63,7 +64,7 @@ jobs:
     - name: Checkout the repo
       uses: actions/checkout@v2
     # Setup ocaml/opam
-    - name: Setup ocaml/opam on Unix
+    - name: Setup ocaml/opam
       uses: avsm/setup-ocaml@v2
       with:
         ocaml-compiler: ${{ matrix.ocaml-version }}

--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -40,7 +40,7 @@ jobs:
 
         # Ocaml versions to use
         # Also test flambda to make sure the installation time is reasonable
-        ocaml-compiler:
+        ocaml-version:
           - 4.14.0
           - ocaml-variants.4.14.0+options,ocaml-option-flambda
 

--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -68,12 +68,13 @@ jobs:
       uses: avsm/setup-ocaml@v2
       with:
         ocaml-compiler: ${{ matrix.ocaml-version }}
-    # Run opam udpate to get an up-to-date repo
-    - name: Update opam repo
-      run: opam update
     # Debug
     - name: Debugging
       run: opam switch list-available
+      if: always ()
+    # Run opam udpate to get an up-to-date repo
+    - name: Update opam repo
+      run: opam update
     # Install the package
     - name: Install package
       run: opam install --with-test ${{ matrix.dolmen-pkg }}

--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -38,16 +38,23 @@ jobs:
           - macos-latest
           - windows-latest
 
-        # Ocaml versions to use
-        # Also test flambda to make sure the installation time is reasonable
-        ocaml-version:
-          - 4.14.0
-          - ocaml-variants.4.14.0+options,ocaml-option-flambda
-
         # Dolmen package to test installation of
         dolmen-pkg:
           - dolmen_bin
           - dolmen_lsp
+
+        # Ocaml versions to use
+        # Also test flambda to make sure the installation time is reasonable
+        # Note that because on windows, switches have different names, we
+        # must do a bit of work manually to get a correct ocaml-version
+        include:
+          - ocaml-version: 4.14.0
+          - ocaml-version: ocaml-variants.4.14.0+options,ocaml-option-flambda
+            os: ubuntu-latest
+          - ocaml-version: ocaml-variants.4.14.0+options,ocaml-option-flambda
+            os: macos-latest
+          - ocaml-version: ocaml-variants.4.14.0+flambda+mingw64c
+            os: windows-latest
 
 
     # Build ENV

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,19 @@
 
+next
+----
+
+### UI
+
+- Fix handling of limits on windows (PR#117)
+
+### Loop
+
+- New module to implement Alarms (size/time limits) (PR#117)
+- Add optional argument to `Pipeline.run` to specify
+  an alarm implementation (PR#117)
+
+
+
 v0.8
 ----
 

--- a/src/bin/errors.ml
+++ b/src/bin/errors.ml
@@ -17,11 +17,11 @@ let exn st = function
     Loop.State.error st Dolmen_loop.Report.Error.user_interrupt ()
 
   (* Timeout, potentially wrapped by the typechecker *)
-  | Dolmen_loop.Pipeline.Out_of_time ->
+  | Dolmen_loop.Alarm.Out_of_time ->
     Format.pp_print_flush Format.std_formatter ();
     Loop.State.error st Dolmen_loop.Report.Error.timeout ()
 
-  | Dolmen_loop.Pipeline.Out_of_space ->
+  | Dolmen_loop.Alarm.Out_of_space ->
     Format.pp_print_flush Format.std_formatter ();
     Format.pp_print_flush Format.err_formatter ();
     Loop.State.error st Dolmen_loop.Report.Error.spaceout ()

--- a/src/loop/alarm.ml
+++ b/src/loop/alarm.ml
@@ -1,0 +1,134 @@
+
+(* Signature & type definition *)
+(* ************************************************************************ *)
+
+exception Out_of_time
+exception Out_of_space
+
+module type S = sig
+
+  type t
+
+  val setup : time:float -> size:float -> t
+
+  val delete : t -> unit
+
+end
+
+type t = (module S)
+
+(* Dummy alarms *)
+(* ************************************************************************ *)
+
+module Dummy : S = struct
+
+  type t = unit
+
+  let setup ~time:_ ~size:_ = ()
+
+  let delete () = ()
+
+end
+
+let dummy : t = (module Dummy)
+
+(* helper functions *)
+(* ************************************************************************ *)
+
+let check_time time_limit =
+  let start_time = Unix.gettimeofday () in
+  function () ->
+    let t = Unix.gettimeofday () -. start_time in
+    if t > time_limit then raise Out_of_time
+
+(* This function analyze the current size of the heap
+   TODO: take into account the minor heap size + stack size
+   TODO: should we only consider the live words ? *)
+let check_size size_limit () =
+  let heap_size = (Gc.quick_stat ()).Gc.heap_words in
+  let s = float heap_size *. float Sys.word_size /. 8. in
+  if s > size_limit then raise Out_of_space
+
+(* Linux alarms *)
+(* ************************************************************************ *)
+
+module Linux : S = struct
+
+  type t = Gc.alarm option
+
+  (* There are two kinds of limits we want to enforce:
+     - a size limit: we use the Gc's alarm function to enforce the limit
+       on the size of the RAM used
+     - a time limit: the Gc alarm is not reliable to enforce this, so instead
+       we use the Unix.timer facilities *)
+  let setup ~time:t ~size:s =
+    (* The Unix.timer works by sending a Sys.sigalrm, so in order to use it,
+       we catch it and raise the Out_of_time exception. *)
+    Sys.set_signal Sys.sigalrm (
+      Sys.Signal_handle (fun _ ->
+          raise Out_of_time)
+    );
+    if t <> infinity then
+      ignore (Unix.setitimer Unix.ITIMER_REAL
+                Unix.{it_value = t; it_interval = 0.01 });
+    if s <> infinity then (Some (Gc.create_alarm (check_size s)))
+    else None
+
+  let delete alarm =
+    (* it's alwyas safe to delete the timer here,
+       even if none was present before. *)
+    ignore (Unix.setitimer Unix.ITIMER_REAL
+              Unix.{it_value = 0.; it_interval = 0. });
+    match alarm with None -> () | Some alarm -> Gc.delete_alarm alarm
+
+end
+
+let linux : t = (module Linux)
+
+
+(* Windows alarms *)
+(* ************************************************************************ *)
+
+module Windows : S = struct
+
+  type t = Gc.alarm option
+
+  (* This function analyze the current size of the heap
+     TODO: take into account the minor heap size + stack size
+     TODO: should we only consider the live words ? *)
+  let check time_limit size_limit =
+    let check_t = check_time time_limit in
+    function () ->
+      check_t ();
+      check_size size_limit ()
+
+  (* There are two kinds of limits we want to enforce:
+     - a size limit: we use the Gc's alarm function to enforce the limit
+       on the size of the RAM used
+     - a time limit: the Gc alarm is not reliable to enforce this, but the
+       Unix.timer facilities are not emulated on windows, so we still use
+       the GC alarm for this, even if it's not that great.
+     TODO: allow to use the time limit only for some passes *)
+  let setup ~time:t ~size:s =
+    if s <> infinity || t <> infinity
+    then (Some (Gc.create_alarm (check t s)))
+    else None
+
+  let delete = function
+    | None -> ()
+    | Some alarm -> Gc.delete_alarm alarm
+
+end
+
+let windows : t = (module Windows)
+
+(* Default alarms *)
+(* ************************************************************************ *)
+
+let default =
+  match Sys.os_type with
+  | "linux" -> linux
+  | "windows" -> windows
+  | _ -> dummy
+
+

--- a/src/loop/alarm.ml
+++ b/src/loop/alarm.ml
@@ -127,8 +127,9 @@ let windows : t = (module Windows)
 
 let default =
   match Sys.os_type with
-  | "linux" -> linux
-  | "windows" -> windows
+  | "Unix" -> linux
+  | "Win32" -> windows
+  | "Cygwin" -> windows (* maybe linux would work, but better safe than sorry *)
   | _ -> dummy
 
 

--- a/src/loop/alarm.mli
+++ b/src/loop/alarm.mli
@@ -30,7 +30,6 @@ type t = (module S)
 val dummy : t
 (** Dummy implementation. Does nothing. *)
 
-
 val linux : t
 (** Linux alarms. Uses Gc alarm for size limits, and
     Unix timers for time limits. Fairly accurate and

--- a/src/loop/alarm.mli
+++ b/src/loop/alarm.mli
@@ -1,0 +1,49 @@
+
+(* This file is free software, part of Dolmen. See file "LICENSE" for more details. *)
+
+(** {2 Some types} *)
+
+exception Out_of_time
+exception Out_of_space
+
+(** The module signature that implements everything needed
+    to use alarms for time and sizes. *)
+module type S = sig
+
+  type t
+  (** The type of active alarms. *)
+
+  val setup : time:float -> size:float -> t
+  (** Create an alarm ith the given size and time limits. *)
+
+  val delete : t -> unit
+  (** Delete an alarm. *)
+
+end
+
+type t = (module S)
+(** An alarm system is a packed module. *)
+
+
+(** {2 Alarm Implementations} *)
+
+val dummy : t
+(** Dummy implementation. Does nothing. *)
+
+
+val linux : t
+(** Linux alarms. Uses Gc alarm for size limits, and
+    Unix timers for time limits. Fairly accurate and
+    reliable. *)
+
+val windows : t
+(** Windows alarms. Uses Gc alarm for size limits as
+    well as time limits. The time limit is not enforced
+    very precisely/reliably because of the use of Gc
+    alarms. *)
+
+val default : t
+(** A default alarm, chosen based on `Sys.os_type`. Can be
+    either {linux} or {windows}, and falls back on {dummy}
+    for unknown os (e.g. js_of_ocaml). *)
+

--- a/src/loop/dune
+++ b/src/loop/dune
@@ -14,7 +14,7 @@
     )
   (modules
     ; Useful utilities
-    Report
+    Alarm Report
     ; Interfaces
     Expr_intf Parser_intf Typer_intf Headers_intf
     ; Implementations

--- a/src/loop/pipeline.ml
+++ b/src/loop/pipeline.ml
@@ -1,7 +1,7 @@
 
 (* This file is free software, part of dolmen. See file "LICENSE" for more information *)
 
-exception Sigint
+exception Sigint = Sys.Break
 exception Out_of_time = Alarm.Out_of_time
 exception Out_of_space = Alarm.Out_of_space
 
@@ -12,10 +12,15 @@ module Make(State : State.S) = struct
 
   (* We want to catch user interruptions *)
   let () =
-    Sys.set_signal Sys.sigint (
-      Sys.Signal_handle (fun _ ->
-          raise Sigint)
-    )
+    match Sys.os_type with
+    | "Win32" | "Cygwin" ->
+      Sys.catch_break true
+    | "Unix" ->
+      Sys.set_signal Sys.sigint (
+        Sys.Signal_handle (fun _ ->
+            raise Sigint)
+      )
+    | _ -> ()
 
   (* Pipeline and execution *)
   (* ************************************************************************ *)

--- a/src/loop/pipeline.ml
+++ b/src/loop/pipeline.ml
@@ -2,6 +2,8 @@
 (* This file is free software, part of dolmen. See file "LICENSE" for more information *)
 
 exception Sigint
+exception Out_of_time = Alarm.Out_of_time
+exception Out_of_space = Alarm.Out_of_space
 
 module Make(State : State.S) = struct
 

--- a/src/loop/pipeline.ml
+++ b/src/loop/pipeline.ml
@@ -2,53 +2,13 @@
 (* This file is free software, part of dolmen. See file "LICENSE" for more information *)
 
 exception Sigint
-exception Out_of_time
-exception Out_of_space
 
 module Make(State : State.S) = struct
 
-  (* GC alarm for time/space limits *)
+  (* Setup *)
   (* ************************************************************************ *)
 
-  (* This function analyze the current size of the heap
-     TODO: take into account the minor heap size
-     TODO: should we only consider the live words ? *)
-  let check size_limit = function () ->
-    let heap_size = (Gc.quick_stat ()).Gc.heap_words in
-    let s = float heap_size *. float Sys.word_size /. 8. in
-    if s > size_limit then
-      raise Out_of_space
-
-  (* There are two kinds of limits we want to enforce:
-     - a size limit: we use the Gc's alarm function to enforce the limit
-       on the size of the RAM used
-     - a time limit: the Gc alarm is not reliable to enforce this, so instead
-       we use the Unix.timer facilities
-     TODO: this does not work on windows.
-     TODO: allow to use the time limit only for some passes *)
-  let setup_alarm t s =
-    if t <> infinity then
-      ignore (Unix.setitimer Unix.ITIMER_REAL
-                Unix.{it_value = t; it_interval = 0.01 });
-    if s <> infinity then (Some (Gc.create_alarm (check s)))
-    else None
-
-  let delete_alarm alarm =
-    (* it's alwyas safe to delete the timer here,
-       even if none was present before. *)
-    ignore (Unix.setitimer Unix.ITIMER_REAL
-              Unix.{it_value = 0.; it_interval = 0. });
-    match alarm with None -> () | Some alarm -> Gc.delete_alarm alarm
-
-  (* The Unix.timer works by sending a Sys.sigalrm, so in order to use it,
-     we catch it and raise the Out_of_time exception. *)
-  let () =
-    Sys.set_signal Sys.sigalrm (
-      Sys.Signal_handle (fun _ ->
-          raise Out_of_time)
-    )
-
-  (* We also want to catch user interruptions *)
+  (* We want to catch user interruptions *)
   let () =
     Sys.set_signal Sys.sigint (
       Sys.Signal_handle (fun _ ->
@@ -177,15 +137,17 @@ module Make(State : State.S) = struct
   let rec run :
     type a.
     finally:(State.t -> (Printexc.raw_backtrace * exn) option -> State.t) ->
-    (State.t -> State.t * a option) -> State.t -> (State.t, a, unit) t -> State.t
-    = fun ~finally g st pipe ->
+    ?alarm:Alarm.t -> (State.t -> State.t * a option) -> State.t ->
+    (State.t, a, unit) t -> State.t
+    = fun ~finally ?(alarm=Alarm.default) g st pipe ->
       let exception Exn of State.t * Printexc.raw_backtrace * exn in
+      let module A = (val alarm) in
       let time = State.get State.time_limit st in
       let size = State.get State.size_limit st in
-      let al = setup_alarm time size in
+      let al = A.setup ~time ~size in
       let exn = { k = fun st bt e ->
           (* delete alarm as soon as possible *)
-          let () = delete_alarm al in
+          let () = A.delete al in
           (* go the the correct handler *)
           raise (Exn (st, bt, e));
         }
@@ -195,28 +157,28 @@ module Make(State : State.S) = struct
 
         (* End of the run, yay ! *)
         | `Done st ->
-          let () = delete_alarm al in
+          let () = A.delete al in
           st
 
         (* Regular case, we finished running the pipeline on one input
            value, let's get to the next one. *)
         | `Continue (st', ()) ->
-          let () = delete_alarm al in
+          let () = A.delete al in
           let st'' = try finally st' None with _ -> st' in
-          run ~finally g st'' pipe
+          run ~finally ~alarm g st'' pipe
 
         (* "Normal" exception case: the exn was raised by an operator, and caught
            then re-raised by the {exn} cotinuation passed to run_aux *)
         | exception Exn (st, bt, e) ->
           (* delete alarm *)
-          let () = delete_alarm al in
+          let () = A.delete al in
           (* Flush stdout and print a newline in case the exn was
              raised in the middle of printing *)
           Format.pp_print_flush Format.std_formatter ();
           Format.pp_print_flush Format.err_formatter ();
           (* Go on running the rest of the pipeline. *)
           let st' = finally st (Some (bt,e)) in
-          run ~finally g st' pipe
+          run ~finally ~alarm g st' pipe
 
         (* Exception case for exceptions, that can realisically occur for all
            asynchronous exceptions, or if some operator was not properly wrapped.
@@ -226,14 +188,14 @@ module Make(State : State.S) = struct
         | exception e ->
           let bt = Printexc.get_raw_backtrace () in
           (* delete alarm *)
-          let () = delete_alarm al in
+          let () = A.delete al in
           (* Flush stdout and print a newline in case the exn was
              raised in the middle of printing *)
           Format.pp_print_flush Format.std_formatter ();
           Format.pp_print_flush Format.err_formatter ();
           (* Go on running the rest of the pipeline. *)
           let st' = finally st (Some (bt,e)) in
-          run ~finally g st' pipe
+          run ~finally ~alarm g st' pipe
       end
 
 end

--- a/src/loop/pipeline.mli
+++ b/src/loop/pipeline.mli
@@ -11,6 +11,13 @@
 *)
 
 exception Sigint
+(** Exception raised when a [Sigint] signal is received. *)
+
+exception Out_of_time
+(** Alias to {Alarm.Out_of_time}. *)
+
+exception Out_of_space
+(** Alias to {Alarm.Out_of_space}. *)
 
 module Make(State : State.S) : sig
   (** Concrete pipelines. *)

--- a/src/loop/pipeline.mli
+++ b/src/loop/pipeline.mli
@@ -11,8 +11,6 @@
 *)
 
 exception Sigint
-exception Out_of_time
-exception Out_of_space
 
 module Make(State : State.S) : sig
   (** Concrete pipelines. *)
@@ -87,7 +85,7 @@ module Make(State : State.S) : sig
 
   val run :
     finally:(State.t -> (Printexc.raw_backtrace * exn) option -> State.t) ->
-    (State.t -> State.t * 'a option) -> State.t ->
+    ?alarm:Alarm.t -> (State.t -> State.t * 'a option) -> State.t ->
     (State.t, 'a, unit) t -> State.t
     (** Loop the evaluation of a pipeline over a generator, and starting options.
         @param finally a function called at the end of every iteration (even if

--- a/src/loop/pipeline.mli
+++ b/src/loop/pipeline.mli
@@ -11,7 +11,8 @@
 *)
 
 exception Sigint
-(** Exception raised when a [Sigint] signal is received. *)
+(** Alias to {Sys.Break}. Raised upon user interrupt / when a
+    {Sys.sigint} signal is received. *)
 
 exception Out_of_time
 (** Alias to {Alarm.Out_of_time}. *)

--- a/src/loop/typer.ml
+++ b/src/loop/typer.ml
@@ -1204,8 +1204,8 @@ module Typer(State : State.S) = struct
     | Smtlib2_Core.Incorrect_sexpression msg ->
       error ~input ~loc st incorrect_sexpression msg
     (* Uncaught exception during type-checking *)
-    | T.Uncaught_exn ((Pipeline.Out_of_time |
-                       Pipeline.Out_of_space |
+    | T.Uncaught_exn ((Alarm.Out_of_time |
+                       Alarm.Out_of_space |
                        Pipeline.Sigint) as exn, bt) ->
       Printexc.raise_with_backtrace exn bt
     | T.Uncaught_exn (exn, bt) ->

--- a/src/lsp/loop.ml
+++ b/src/lsp/loop.ml
@@ -17,8 +17,8 @@ let handle_exn st = function
 
   (* Simple error cases *)
   | Dolmen_loop.Pipeline.Sigint -> Error "user interrupt"
-  | Dolmen_loop.Pipeline.Out_of_time -> Error "timeout"
-  | Dolmen_loop.Pipeline.Out_of_space -> Error "memoryout"
+  | Dolmen_loop.Alarm.Out_of_time -> Error "timeout"
+  | Dolmen_loop.Alarm.Out_of_space -> Error "memoryout"
   (* Fallback *)
   | exn ->
     let bt = Printexc.get_raw_backtrace () in


### PR DESCRIPTION
Introduce a separate implementation of time/size alarms for windows. That should make it so that CI can test windows.