### PR TITLE
Workaround indirect base dependency

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,14 +4,16 @@ next
 
 ### UI
 
-- Fix handling of limits on windows (PR#117)
+- Fix handling of size/time limits on windows (PR#117)
+- Fix spurious printing of backtraces (PR#118)
 
 ### Loop
 
 - New module to implement Alarms (size/time limits) (PR#117)
 - Add optional argument to `Pipeline.run` to specify
   an alarm implementation (PR#117)
-
+- Add a `bt` key to the state to record whether we should print
+  backtraces (PR#118)
 
 
 v0.8

--- a/src/bin/main.ml
+++ b/src/bin/main.ml
@@ -32,8 +32,9 @@ let finally st e =
   | None -> st
   | Some (bt,exn) ->
     (* Print the backtrace if requested *)
-    if Printexc.backtrace_status () then
-      Printexc.print_raw_backtrace stdout bt;
+    if Loop.State.(get bt) st then (
+      Format.eprintf "foo ?!@.";
+      Printexc.print_raw_backtrace stdout bt);
     handle_exn st exn
 
 let run st =

--- a/src/bin/options.ml
+++ b/src/bin/options.ml
@@ -340,13 +340,17 @@ let mk_run_state
   let () = Option.iter Gc.set gc_opt in
   let () = set_color Unix.stdout Format.std_formatter colors in
   let () = set_color Unix.stderr Format.err_formatter colors in
+  (* base (which is a transitive dependency, due to farith),
+     unconditionally enables backtraces, which is fine. But that means that
+     for our purpose, we need to store whether to print the backtraces somewhere
+     else, since we cannot reuse the [backtrace_status ()]. *)
   let () = if bt then Printexc.record_backtrace true in
   let () = if gc then at_exit (fun () -> Gc.print_stat stdout;) in
   let () = if abort_on_bug then Dolmen_loop.Code.abort Dolmen_loop.Code.bug in
   (* State creation *)
   Loop.State.empty
   |> Loop.State.init
-    ~debug ~report_style ~reports
+    ~bt ~debug ~report_style ~reports
     ~max_warn ~time_limit ~size_limit
     ~logic_file ~response_file
   |> Loop.Parser.init

--- a/src/loop/state.ml
+++ b/src/loop/state.ml
@@ -144,6 +144,7 @@ let update k f t =
 (* ************************************************************************* *)
 
 let pipe = "state"
+let bt : bool key = create_key ~pipe "bt"
 let debug : bool key = create_key ~pipe "debug"
 let reports : Report.Conf.t key = create_key ~pipe "reports"
 let report_style : report_style key = create_key ~pipe "report_style"
@@ -157,6 +158,7 @@ let logic_file : Logic.language file key = create_key ~pipe "logic_file"
 let response_file : Response.language file key = create_key ~pipe "response_file"
 
 let init
+    ?bt:(bt_value=(Printexc.backtrace_status ()))
     ~debug:debug_value
     ~report_style:report_style_value
     ~reports:reports_value
@@ -168,6 +170,7 @@ let init
     ~response_file:response_file_value
     st =
   st
+  |> set bt bt_value
   |> set debug debug_value
   |> set report_style report_style_value
   |> set reports reports_value


### PR DESCRIPTION
So, since the merge of the model verificaiton code, we have an indirect independency on `base` (through `farith`), which is a bit annoying because it unconditionally sets backtrace recording.