### PR TITLE
Fix link to the smtlib module in documentation

### DIFF
--- a/src/index.mld
+++ b/src/index.mld
@@ -63,7 +63,7 @@ Individual language parsers are available through the following modules:
 {!modules:
 Dolmen_dimacs
 Dolmen_icnf
-Dolmen_smtlib
+Dolmen_smtlib2
 Dolmen_tptp
 Dolmen_zf
 }


### PR DESCRIPTION
The link to the module `Dolmen_smtlib` in the documentation (http://gbury.github.io/dolmen/0.7/dolmen/index.html) does not work. I guess this can be solved by suggested fix of module's name. 