### PR TITLE
assume all funs are recursive in AE

### DIFF
--- a/src/languages/ae/ast.ml
+++ b/src/languages/ae/ast.ml
@@ -197,8 +197,8 @@ module type Statement = sig
   val record_type : ?loc:location -> id -> term list -> (id * term) list -> t
   (** Record type definition. *)
 
-  val fun_def : ?loc:location -> id -> term list -> term list -> term -> term -> t
-  (** Function definition. *)
+  val funs_def_rec : ?loc:location -> (id * term list * term list * term * term) list -> t
+  (** Declare a list of mutually recursive functions. *)
 
   val pred_def : ?loc:location -> id -> term list -> term list -> term -> t
   (** Predicate definition. *)

--- a/src/languages/ae/parser.mly
+++ b/src/languages/ae/parser.mly
@@ -541,7 +541,7 @@ decl:
     LEFTPAR args=separated_list(COMMA, logic_binder) RIGHTPAR
     COLON ret_ty=primitive_type EQUAL body=lexpr
     { let loc = L.mk_pos $startpos $endpos in
-      S.fun_def ~loc f [] args ret_ty body }
+      S.funs_def_rec ~loc [f, [], args, ret_ty, body] }
 
   | PRED p=raw_named_ident EQUAL body=lexpr
     { let loc = L.mk_pos $startpos $endpos in


### PR DESCRIPTION
While trying to fix the issue #121 I got the following error:
```
File "./tmp.ae", line 6, character 4-15:
6 |   | Cons(_, l') -> length(l') + 1
        ^^^^^^^^^^^
Error The typechecker inferred the implicit type to provide to an
      application.
      That inference lead to infer that type to contain the variable `w1`
      which is not in the scope of the inferred type.
      The application is located at line 6, character 4-15
      Variable `w1` was bound at <location missing>.
```