### PR TITLE
Multliple fixes for recursive definitions 

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,15 +19,15 @@ next
 
 - Fix a bug related to alt-ergos function definition, which
   were previously alwyas non-recursive. Now, alt-ergo's function
-  definitions are always recursive (PR#XXX)
+  definitions are always recursive (PR#123)
 
 ### Typing
 
 - Properly add binding locations for implicit type variables
-  (PR#XXX)
+  (PR#123)
 - Ensure that type of recursively defined symbols are freshened
   to avoid type variables sharing between declaration and
-  definition (PR#XXX)
+  definition (PR#123)
 
 ### Loop
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,20 @@ next
 - The LSP now sends an empty list of diagnostics upon closing
   a file (PR#116)
 
+### Parsing
+
+- Fix a bug related to alt-ergos function definition, which
+  were previously alwyas non-recursive. Now, alt-ergo's function
+  definitions are always recursive (PR#XXX)
+
+### Typing
+
+- Properly add binding locations for implicit type variables
+  (PR#XXX)
+- Ensure that type of recursively defined symbols are freshened
+  to avoid type variables sharing between declaration and
+  definition (PR#XXX)
+
 ### Loop
 
 - New module to implement Alarms (size/time limits) (PR#117)

--- a/src/interface/stmt.ml
+++ b/src/interface/stmt.ml
@@ -195,6 +195,11 @@ module type Logic = sig
       i.e f is a function symbol with arguments [args], and which returns the value
       [body] which is of type [ret]. *)
 
+  val fun_def_rec : ?loc:location -> id -> term list -> term list -> term -> term -> t
+  (** Symbol definition. [fun_def_rec f vars args ret body] means that "f(args) = (body : ret)",
+      i.e f is a recursive function symbol with arguments [args], and which returns the value
+      [body] which is of type [ret]. *)
+
   val pred_def    : ?loc:location -> id -> term list -> term list -> term -> t
   (** Symbol definition. [pred_def p vars args body] means that "p(args) = (body : bool)",
       i.e [p] is a predicate symbol with arguments [args], and which returns the value

--- a/src/interface/term.ml
+++ b/src/interface/term.ml
@@ -419,6 +419,9 @@ module type Tff = sig
     type t
     (** The type of constant symbols that can occur in terms *)
 
+    val print : Format.formatter -> t -> unit
+    (** Printing function for term constants. *)
+
     val compare : t -> t -> int
     (** Comparison function on constant symbols. *)
 

--- a/src/interface/ty.ml
+++ b/src/interface/ty.ml
@@ -136,6 +136,10 @@ module type Tff = sig
   val view : t -> view
   (** Partial view of a type. *)
 
+  val freshen : t -> t
+  (** Replaces all bound variables in a type, ensuring that the returned type
+      contains only fresh bound type variables. *)
+
 end
 
 module type Thf = sig

--- a/src/languages/ae/ast.ml
+++ b/src/languages/ae/ast.ml
@@ -197,7 +197,7 @@ module type Statement = sig
   val record_type : ?loc:location -> id -> term list -> (id * term) list -> t
   (** Record type definition. *)
 
-  val fun_def : ?loc:location -> id -> term list -> term list -> term -> term -> t
+  val fun_def_rec : ?loc:location -> id -> term list -> term list -> term -> term -> t
   (** Function definition. *)
 
   val pred_def : ?loc:location -> id -> term list -> term list -> term -> t

--- a/src/languages/ae/parser.mly
+++ b/src/languages/ae/parser.mly
@@ -541,7 +541,7 @@ decl:
     LEFTPAR args=separated_list(COMMA, logic_binder) RIGHTPAR
     COLON ret_ty=primitive_type EQUAL body=lexpr
     { let loc = L.mk_pos $startpos $endpos in
-      S.fun_def ~loc f [] args ret_ty body }
+      S.fun_def_rec ~loc f [] args ret_ty body }
 
   | PRED p=raw_named_ident EQUAL body=lexpr
     { let loc = L.mk_pos $startpos $endpos in

--- a/src/loop/typer.ml
+++ b/src/loop/typer.ml
@@ -147,6 +147,12 @@ let print_reason ?(already=false) fmt r =
   | Declared (file, d) ->
     Format.fprintf fmt "was%a declared at %a"
       pp_already () Dolmen.Std.Loc.fmt_pos (Dolmen.Std.Loc.loc file (decl_loc d))
+  | Implicit_in_def (file, d) ->
+    Format.fprintf fmt "was%a implicitly introduced in the definition at %a"
+      pp_already () Dolmen.Std.Loc.fmt_pos (Dolmen.Std.Loc.loc file d.loc)
+  | Implicit_in_decl (file, d) ->
+    Format.fprintf fmt "was%a implicitly introduced in the definition at %a"
+      pp_already () Dolmen.Std.Loc.fmt_pos (Dolmen.Std.Loc.loc file (decl_loc d))
 
 let print_reason_opt ?already fmt = function
   | Some r -> print_reason ?already fmt r

--- a/src/loop/typer.ml
+++ b/src/loop/typer.ml
@@ -151,7 +151,7 @@ let print_reason ?(already=false) fmt r =
     Format.fprintf fmt "was%a implicitly introduced in the definition at %a"
       pp_already () Dolmen.Std.Loc.fmt_pos (Dolmen.Std.Loc.loc file d.loc)
   | Implicit_in_decl (file, d) ->
-    Format.fprintf fmt "was%a implicitly introduced in the definition at %a"
+    Format.fprintf fmt "was%a implicitly introduced in the declaration at %a"
       pp_already () Dolmen.Std.Loc.fmt_pos (Dolmen.Std.Loc.loc file (decl_loc d))
 
 let print_reason_opt ?already fmt = function

--- a/src/loop/typer.ml
+++ b/src/loop/typer.ml
@@ -153,6 +153,9 @@ let print_reason ?(already=false) fmt r =
   | Implicit_in_decl (file, d) ->
     Format.fprintf fmt "was%a implicitly introduced in the declaration at %a"
       pp_already () Dolmen.Std.Loc.fmt_pos (Dolmen.Std.Loc.loc file (decl_loc d))
+  | Implicit_in_term (file, ast) ->
+    Format.fprintf fmt "was%a implicitly introduced in the term at %a"
+      pp_already () Dolmen.Std.Loc.fmt_pos (Dolmen.Std.Loc.loc file ast.loc)
 
 let print_reason_opt ?already fmt = function
   | Some r -> print_reason ?already fmt r

--- a/src/standard/expr.mli
+++ b/src/standard/expr.mli
@@ -653,6 +653,10 @@ module Ty : sig
   val fv : t -> Var.t list
   (** Returns the list of free variables in the type. *)
 
+  val freshen : t -> t
+  (** Freshen a type, replacing all its bound variables by new/fresh
+      type variables. *)
+
   val unify : t -> t -> t option
   (** Try and unify two types. *)
 

--- a/src/standard/statement.ml
+++ b/src/standard/statement.ml
@@ -498,6 +498,11 @@ let fun_def ?loc id vars params ret_ty body =
     def ?loc id ~vars ~params ret_ty body
   ]
 
+let fun_def_rec ?loc id vars params ret_ty body =
+  mk_defs ?loc ~recursive:true [
+    def ?loc id ~vars ~params ret_ty body
+  ]
+
 let pred_def ?loc id vars params body =
   let attrs = [Term.const ?loc Id.predicate_def] in
   let ret_ty = Term.prop ?loc () in

--- a/src/typecheck/intf.ml
+++ b/src/typecheck/intf.ml
@@ -157,6 +157,7 @@ module type Formulas = sig
     | Declared of Dolmen.Std.Loc.file * Dolmen.Std.Statement.decl
     | Implicit_in_def of Dolmen.Std.Loc.file * Dolmen.Std.Statement.def
     | Implicit_in_decl of Dolmen.Std.Loc.file * Dolmen.Std.Statement.decl
+    | Implicit_in_term of Dolmen.Std.Loc.file * Dolmen.Std.Term.t
   (** The type of reasons for constant typing *)
 
   type binding = [

--- a/src/typecheck/intf.ml
+++ b/src/typecheck/intf.ml
@@ -155,6 +155,8 @@ module type Formulas = sig
     | Inferred of Dolmen.Std.Loc.file * Dolmen.Std.Term.t
     | Defined of Dolmen.Std.Loc.file * Dolmen.Std.Statement.def
     | Declared of Dolmen.Std.Loc.file * Dolmen.Std.Statement.decl
+    | Implicit_in_def of Dolmen.Std.Loc.file * Dolmen.Std.Statement.def
+    | Implicit_in_decl of Dolmen.Std.Loc.file * Dolmen.Std.Statement.decl
   (** The type of reasons for constant typing *)
 
   type binding = [

--- a/src/typecheck/misc.ml
+++ b/src/typecheck/misc.ml
@@ -48,6 +48,14 @@ module Lists = struct
     | a :: r1, b :: r2, c :: r3 -> (f a b c) :: (map3 f r1 r2 r3)
     | _ -> raise (Invalid_argument "Misc.Lists.map3")
 
+  let fold_left_map f accu l =
+    let rec aux f accu l_accu = function
+      | [] -> accu, List.rev l_accu
+      | x :: l ->
+        let accu, x = f accu x in
+        aux f accu (x :: l_accu) l in
+    aux f accu [] l
+
 end
 
 (* String manipulation *)

--- a/src/typecheck/misc.mli
+++ b/src/typecheck/misc.mli
@@ -41,6 +41,9 @@ module Lists : sig
   val map3 : ('a -> 'b -> 'c -> 'd) -> 'a list -> 'b list -> 'c list -> 'd list
   (** Same as {!List.map2} but for 3 lists. *)
 
+  val fold_left_map : ('a -> 'b -> 'a * 'c) -> 'a -> 'b list -> 'a * 'c list
+  (** Same as {!List.fold_left_map} (which is onlt available for ocaml >= 4.11). *)
+
 end
 
 (** String helper *)

--- a/src/typecheck/thf.ml
+++ b/src/typecheck/thf.ml
@@ -1268,7 +1268,7 @@ module Make
   let free_wildcards_to_quant_vars =
     let wildcard_univ_counter = ref 0 in
     (fun ctx env wildcards ->
-       List.fold_left_map (fun env (w, _) ->
+       Misc.Lists.fold_left_map (fun env (w, _) ->
            incr wildcard_univ_counter;
            let v =
              Ty.Var.mk (Format.asprintf "w%d" !wildcard_univ_counter)

--- a/src/typecheck/thf.ml
+++ b/src/typecheck/thf.ml
@@ -207,6 +207,8 @@ module Make
     | Inferred of Loc.file * Ast.t
     | Defined of Loc.file * Stmt.def
     | Declared of Loc.file * Stmt.decl
+    | Implicit_in_def of Loc.file * Stmt.def
+    | Implicit_in_decl of Loc.file * Stmt.decl
   (** The type of reasons for constant typing *)
 
   type binding = [
@@ -1068,7 +1070,8 @@ module Make
     | Bound (_, t) | Inferred (_, t) ->
       _warn env (Ast t) (Unused_type_variable (kind, v))
     (* variables should not be declare-able nor builtin *)
-    | Builtin | Reserved | Declared _ | Defined _ ->
+    | Builtin | Reserved | Declared _ | Defined _
+    | Implicit_in_def _ | Implicit_in_decl _ ->
       assert false
 
   let find_term_var_reason env v =
@@ -1081,7 +1084,8 @@ module Make
       _warn env (Ast t) (Unused_term_variable (kind, v))
     (* variables should not be declare-able nor builtin,
        and we do not use any term wildcards. *)
-    | Builtin | Reserved | Declared _ | Defined _ ->
+    | Builtin | Reserved | Declared _ | Defined _
+    | Implicit_in_def _ | Implicit_in_decl _ ->
       assert false
 
 
@@ -1262,21 +1266,31 @@ module Make
 
   let free_wildcards_to_quant_vars =
     let wildcard_univ_counter = ref 0 in
-    (fun wildcards ->
-       List.map (fun (w, _) ->
+    (fun ctx env wildcards ->
+       List.fold_left_map (fun env (w, _) ->
            incr wildcard_univ_counter;
            let v =
              Ty.Var.mk (Format.asprintf "w%d" !wildcard_univ_counter)
+           in
+           let env =
+             match ctx with
+             | `Check -> env
+             | `Def def ->
+               let reason = Implicit_in_def (env.file, def) in
+               { env with type_locs = E.add v reason env.type_locs; }
+             | `Decl decl ->
+               let reason = Implicit_in_decl (env.file, decl) in
+               { env with type_locs = E.add v reason env.type_locs; }
            in
            Ty.set_wildcard w (Ty.of_var v);
            (* the wildcard wes generated from the term being typechecked,
               so it is at least used where it was generated. *)
            mark_ty_var_as_used v;
-           v
-         ) wildcards
+           env, v
+         ) env wildcards
     )
 
-  let finalize_wildcards env ast =
+  let finalize_wildcards ctx env ast =
     let free_wildcards =
       _wrap2 env ast set_wildcards_and_return_free_wildcards env []
     in
@@ -1286,30 +1300,33 @@ module Make
         (* Ensure that the wildcards are properly instantiated, so that
            they cannot be instantiated after we have built the
            quantification *)
-        `Univ (tys, lazy (free_wildcards_to_quant_vars tys))
+        let env, vars = free_wildcards_to_quant_vars ctx env tys in
+        `Univ (env, tys, vars)
       | free_wildcards, Forbidden ->
         _error env (Ast ast) (Unbound_type_wildcards free_wildcards)
     end
 
-  let finalize_wildcards_prop env ast prop =
-    match finalize_wildcards env ast with
-    | `No_free_wildcards -> prop
-    | `Univ (_, lazy vars) -> _wrap2 env ast T.all (vars, []) prop
+  let finalize_wildcards_prop ctx env ast prop =
+    match finalize_wildcards ctx env ast with
+    | `No_free_wildcards -> env, prop
+    | `Univ (env, _, vars) ->
+      let res = _wrap2 env ast T.all (vars, []) prop in
+      env, res
 
-  let finalize_wildcards_ty env ast ty =
-    match finalize_wildcards env ast with
-    | `No_free_wildcards -> ty
-    | `Univ (_, lazy vars) -> Ty.pi vars ty
+  let finalize_wildcards_ty ctx env ast ty =
+    match finalize_wildcards ctx env ast with
+    | `No_free_wildcards -> env, ty
+    | `Univ (env, _, vars) -> env, Ty.pi vars ty
 
-  let finalize_wildcards_def env ast =
-    match finalize_wildcards env ast with
-    | `No_free_wildcards -> []
-    | `Univ (_, lazy vars) -> vars
+  let finalize_wildcards_def ctx env ast =
+    match finalize_wildcards ctx env ast with
+    | `No_free_wildcards -> env, []
+    | `Univ (env, _, vars) -> env, vars
 
-  let check_no_free_wildcards env ast =
-    match finalize_wildcards env ast with
+  let check_no_free_wildcards ctx env ast =
+    match finalize_wildcards ctx env ast with
     | `No_free_wildcards -> ()
-    | `Univ (free_wildcards, _) ->
+    | `Univ (env, free_wildcards, _) ->
       _error env (Ast ast) (Unbound_type_wildcards free_wildcards)
 
 
@@ -2129,7 +2146,7 @@ module Make
     let ty_vars, env = add_type_vars env ttype_vars in
     let l = List.map (fun (id, t) ->
         let ty = parse_ty env t in
-        check_no_free_wildcards env t;
+        check_no_free_wildcards `Check env t;
         cst_path env (Id.name id), ty
       ) fields in
     let field_list = T.define_record ty_cst ty_vars l in
@@ -2145,7 +2162,7 @@ module Make
     let cstrs_with_ids = List.map (fun (id, args) ->
         id, List.map (fun t ->
             let ty, dstr = parse_inductive_arg env t in
-            check_no_free_wildcards env t;
+            check_no_free_wildcards `Check env t;
             t, ty, dstr
           ) args
       ) cstrs in
@@ -2181,27 +2198,27 @@ module Make
     | `Term_decl _, Record _ -> assert false
     | `Type_decl c, Record r -> record env t c r
 
-  let parse_decl env tags (t : Stmt.decl) =
+  let parse_decl tags env (t : Stmt.decl) =
     match t with
     | Abstract { id; ty = ast; _ } ->
       begin match parse_sig env ast with
         | `Ty_cstr n ->
-          check_no_free_wildcards env ast;
+          check_no_free_wildcards `Check env ast;
           let c = mk_ty_cst env (Id.name id) n in
           List.iter (function
               | Set (tag, v) -> Ty.Const.set_tag c tag v
               | Add (tag, v) -> Ty.Const.add_tag c tag v
             ) tags;
-          id, `Type_decl c
+          env, (id, `Type_decl c)
         | `Fun_ty (vars, args, ret) ->
           let ty = Ty.pi vars (Ty.arrow args ret) in
-          let ty = finalize_wildcards_ty env ast ty in
+          let env, ty = finalize_wildcards_ty (`Decl t) env ast ty in
           let f = mk_term_cst env (Id.name id) ty in
           List.iter (function
               | Set (tag, v) -> T.Const.set_tag f tag v
               | Add (tag, v) -> T.Const.add_tag f tag v
             ) tags;
-          id, `Term_decl f
+          env, (id, `Term_decl f)
       end
     | Record { id; vars; _ }
     | Inductive { id; vars; _ } ->
@@ -2211,7 +2228,7 @@ module Make
           | Set (tag, v) -> Ty.Const.set_tag c tag v
           | Add (tag, v) -> Ty.Const.add_tag c tag v
         ) tags;
-      id, `Type_decl c
+      env, (id, `Type_decl c)
 
   let record_decl env (id, tdecl) (t : Stmt.decl) =
     match tdecl with
@@ -2222,7 +2239,7 @@ module Make
     let tags =
       List.flatten @@ List.map (fun ast ->
         let l = parse_attr env ast in
-        check_no_free_wildcards env ast;
+        check_no_free_wildcards `Check env ast;
         l
         ) attrs
     in
@@ -2230,7 +2247,7 @@ module Make
       (* Check well-foundedness *)
       check_well_founded env d d.contents;
       (* First pre-parse all definitions and generate the typed symbols for them *)
-      let parsed = List.map (parse_decl env tags) d.contents in
+      let env, parsed = Misc.Lists.fold_left_map (parse_decl tags) env d.contents in
       (* Then, since the decls are recursive, register in the global env the type
          const for each decl before fully parsing and defining them. *)
       let () = List.iter2 (record_decl env) parsed d.contents in
@@ -2243,7 +2260,7 @@ module Make
     end else begin
       List.map (fun t ->
           (* First pre-parse all definitions and generate the typed symbols for them *)
-          let parsed = parse_decl env tags t in
+          let env, parsed = parse_decl tags env t in
           (* Then parse the complete type definition and define them. *)
           let () = define_decl env parsed t in
           (* Finally record them in the state *)
@@ -2294,10 +2311,10 @@ module Make
       _expected env "ttype or a type" d.ret_ty (Some res)
 
   let close_wildcards_in_sig (env, vars, params, ssig) (d : Stmt.def) =
-    let l = finalize_wildcards_def env d.ret_ty in
+    let env, l = finalize_wildcards_def (`Def d) env d.ret_ty in
     env, l @ vars, params, ssig
 
-  let create_id_for_def ~defs tags (env, vars, params, ssig) (d: Stmt.def) =
+  let create_id_for_def ~freshen ~defs tags (env, vars, params, ssig) (d: Stmt.def) =
     match ssig with
     | `Ty_def ->
       assert (params = []);
@@ -2313,6 +2330,7 @@ module Make
     | `Term_def ret_ty ->
       let params_tys = List.map (fun p -> T.Var.ty p) params in
       let ty = Ty.pi vars (Ty.arrow params_tys ret_ty) in
+      let ty = if freshen then Ty.freshen ty else ty in
       let f = mk_term_cst env (Id.name d.id) ty in
       List.iter (function
           | Set (tag, v) -> T.Const.set_tag f tag v
@@ -2346,9 +2364,9 @@ module Make
       _id_def_conflict env d.loc d.id (with_reason (find_reason env bound) bound)
 
 
-  let id_for_def ~mode ~defs tags ssig d =
+  let id_for_def ~freshen ~mode ~defs tags ssig d =
     match mode with
-    | `Create_id -> create_id_for_def ~defs tags ssig d
+    | `Create_id -> create_id_for_def ~freshen ~defs tags ssig d
     | `Use_declared_id -> lookup_id_for_def tags ssig d
 
   let parse_def (env, _vars, _params, ssig) (d : Stmt.def) =
@@ -2361,7 +2379,7 @@ module Make
     | _ -> assert false
 
   let finalize_def id (env, vars, params, _ssig) (ast, ret) =
-    check_no_free_wildcards env ast;
+    check_no_free_wildcards `Check env ast;
     match id, ret with
     (* type alias *)
     | `Ty (id, c), `Ty body ->
@@ -2383,7 +2401,7 @@ module Make
       let envs = List.map (fun _ -> split_env_for_def env) d.contents in
       let sigs = List.map2 parse_def_sig envs d.contents in
       let sigs = List.map2 close_wildcards_in_sig sigs d.contents in
-      let ids = List.map2 (id_for_def ~defs:d ~mode tags) sigs d.contents in
+      let ids = List.map2 (id_for_def ~freshen:true ~defs:d ~mode tags) sigs d.contents in
       let defs = List.map2 parse_def sigs d.contents in
       Misc.Lists.map3 finalize_def ids sigs defs
     end else begin
@@ -2392,7 +2410,7 @@ module Make
           let ssig = parse_def_sig env t in
           let def = parse_def ssig t in
           let ssig = close_wildcards_in_sig ssig t in
-          let id = id_for_def ~defs:d ~mode tags ssig t in
+          let id = id_for_def ~freshen:false ~defs:d ~mode tags ssig t in
           finalize_def id ssig def
         ) d.contents
     end
@@ -2402,6 +2420,7 @@ module Make
 
   let parse env ast =
     let res = parse_prop env ast in
-    finalize_wildcards_prop env ast res
+    let _env, res = finalize_wildcards_prop `Check env ast res in
+    res
 
 end

--- a/tests/typing/pass/ae/adts/dune
+++ b/tests/typing/pass/ae/adts/dune
@@ -18,4 +18,21 @@
   (action (diff adts_1.expected adts_1.full)))
 
 
+; Test for length.ae
+; Full mode test
+
+(rule
+   (target  length.full)
+   (deps    (:input length.ae))
+   (package dolmen_bin)
+   (action (chdir %{workspace_root}
+            (with-outputs-to %{target}
+             (with-accepted-exit-codes (or 0 (not 0))
+              (run dolmen --mode=full --color=never %{input} %{read-lines:flags.dune}))))))
+(rule
+  (alias runtest)
+  (package dolmen_bin)
+  (action (diff length.expected length.full)))
+
+
 ; Auto-generated part end

--- a/tests/typing/pass/ae/adts/length.ae
+++ b/tests/typing/pass/ae/adts/length.ae
@@ -1,0 +1,11 @@
+type 'a t = Cons of {elt : 'a; tail : 'a t} | Nil
+
+function length (list : 'a t) : int =
+  match list with
+  | Nil -> 0
+  | Cons(_, l') -> length(l') + 1
+end
+
+logic l : int t
+
+goal g: length(l) <= 4


### PR DESCRIPTION
- AE's definitions are recursive by default
- when creating/binding implicit type variables (such as in AE's function definitions), make sure to add them to the env (else, they can trigger an out_of_scope error for wildcards)
- When dealing with recursive definitions, freshen the type of the being-defined constants to ensure that recursive uses are properly type-checked (else, a type variable may appear both in the type of an argument *and* polymorphically bound in the type of the function symbol, which breaks the type-checking)