### PR TITLE
Add attributes on all decls/defs and properly attach them

### DIFF
--- a/src/standard/statement.mli
+++ b/src/standard/statement.mli
@@ -21,6 +21,7 @@ type abstract = {
   id : Id.t;
   ty : term;
   loc : location;
+  attrs : term list;
 }
 (** The type for abstract type definitions. *)
 
@@ -58,11 +59,12 @@ type decl =
 
 type def = {
   id : Id.t;
+  vars : term list;
+  params : term list;
+  ret_ty : term;
+  body : term;
   loc : location;
-  vars    : term list;
-  params  : term list;
-  ret_ty  : term;
-  body    : term;
+  attrs : term list;
 }
 (** Term definition. *)
 


### PR DESCRIPTION
The main difference is that with this PR, we can now attach attributes to an individual definition (rather than attach it to the group). This is used in the case of predicates to correctly attach the predicate attribute to the individual definition, which should fix a bug with alt-ergo.