### PR TITLE
Add interleaved mode for model verification

### DIFF
--- a/src/bin/hints.ml
+++ b/src/bin/hints.ml
@@ -1,0 +1,13 @@
+
+(* This file is free software, part of dolmen. See file "LICENSE" for more information *)
+
+let model ~check_model ~check_model_mode =
+  (* Model mode hints *)
+  if check_model && (check_model_mode = Dolmen_model.Loop.Full) then
+      Dolmen_loop.Report.add_hint Dolmen_loop.Report.Error.spaceout
+        (Format.dprintf "%a" Format.pp_print_text
+           "The full mode for checking model can use up a lot of memory, \
+            you might want to try using the `--check-model-mode=interleave` option.");
+  ()
+
+

--- a/src/loop/report.ml
+++ b/src/loop/report.ml
@@ -19,7 +19,7 @@ type ('kind, 'param) aux = {
 
     (* short message printing *)
     message : Format.formatter -> 'param -> unit;
-    hints : ('param -> (Format.formatter -> unit) option) list;
+    mutable hints : ('param -> (Format.formatter -> unit) option) list;
 
     (* long documentation *)
     name : string;
@@ -88,6 +88,10 @@ let mk_warning
   let id = !warning_count in
   incr warning_count;
   mk_aux ~kind:(Warning { id; }) ~code ~mnemonic ~message ?hints ~name ?doc ()
+
+let add_hint t hint =
+  let new_hint _ = Some (hint) in
+  t.hints <- new_hint :: t.hints
 
 
 (* Warnings interface *)

--- a/src/loop/report.mli
+++ b/src/loop/report.mli
@@ -3,12 +3,15 @@
 
 (** {2 Some types} *)
 
-type 'a error
-type 'a warning
+type ('kind, 'param) aux
+type 'a error = ([`Error], 'a) aux
+type 'a warning = ([`Warning], 'a) aux
 
 type any_error = Any_err : _ error -> any_error
 type any_warning = Any_warn : _ warning -> any_warning
 
+val add_hint : _ aux -> (Format.formatter -> unit) -> unit
+(** Dynamically add a hint to a warning/error. *)
 
 (** {2 Reports} *)
 

--- a/src/loop/state.ml
+++ b/src/loop/state.ml
@@ -151,6 +151,7 @@ let set k v t =
 let update k f t =
   set k (f (get k t)) t
 
+let key_name { name; _ } = name
 
 (* Some common keys *)
 (* ************************************************************************* *)

--- a/src/loop/typer_intf.ml
+++ b/src/loop/typer_intf.ml
@@ -111,7 +111,8 @@ module type Typer_Full = sig
   (** The typechecker needs to know whether we are checking models or not. *)
 
   val smtlib2_forced_logic : string option key
-  (** The typechecker needs to know whether we are checking models or not. *)
+  (** Force the typechecker to use the given logic (instead of using the one declared
+      in the `set-logic` statement). *)
 
   val init :
     ?ty_state:ty_state ->

--- a/src/typecheck/intf.ml
+++ b/src/typecheck/intf.ml
@@ -501,11 +501,14 @@ module type Formulas = sig
   val find_global : env -> Dolmen.Std.Id.t -> [ cst | not_found ]
   (** Try and find the given id in the set of globally bound constants. *)
 
+  val find_global_st : state -> Dolmen.Std.Id.t -> [ cst | not_found ]
+  (** Try and find the given id in the set of globally bound constants. *)
+
   val find_builtin : env -> Dolmen.Std.Id.t -> [ builtin | not_found ]
   (** Try and find the given id in the set of bound builtin symbols. *)
 
   val find_bound : env -> Dolmen.Std.Id.t -> [ bound | not_found ]
-  (** Try and find a bound identifier in the env, whetehr it be locally bound
+  (** Try and find a bound identifier in the env, whether it be locally bound
       (such as bound variables), constants bound at top-level, or builtin
       symbols bound by the builtin theory. *)
 

--- a/src/typecheck/thf.ml
+++ b/src/typecheck/thf.ml
@@ -577,10 +577,13 @@ module Make
         | None -> `Not_found
       end
 
-  let find_global env id : [cst | not_found] =
-    match M.find_opt id env.st.csts with
+  let find_global_st st id : [ cst | not_found ] =
+    match M.find_opt id st.csts with
     | Some res -> (res :> [cst | not_found])
     | None -> `Not_found
+
+  let find_global env id : [cst | not_found] =
+    find_global_st env.st id
 
   let find_builtin env id : [builtin | not_found] =
     match env.builtins env (Id id) with


### PR DESCRIPTION
Should fix #103 

This adds a new mode for checking models, in which we interleave the input problem file and the model file. The interleaving works as follows:
1) first the input problem file is checked, until a definition or assertion or check-sat is reached
2) then we read the model file and create a model from its definitions, until we reach a definition for a symbol that is not yet declared (i.e. a definition for a symbol from the input file, that we have not seen yet)
3) then we try and evaluate the assertion/definition from the input file using the (possibly incomplete) model we got from 2
4) we loop (i.e. goto step 1).

This makes it so that dolmen does not need to keep all definitions/assertions from the input file in memory. For instance, on the problem mentionned in #103 , checking the model now succeeds while using around 500M of memory (cc @bobot ).

However, this strategy can fail on some technically allowed combination of input file and model. For instance consider the following input file and model file:

```smt2
(set-logic ALL)
(declare-fun f (Int) Int)
(assert (= (f 0) 0))
(declare-fun g (Int) Int)
(assert (= (g 0) 1))
(check-sat)
```

```smt2
sat
(model
  (define-fun g ((x Int)) Int 1)
  (define-fun f ((x Int)) Int 0)
)
```

In interleaved mode, this will not be deemed correct, as when reading the assertion at line 3 (the one about `(f 0)`), dolmen will read the model file, see the definition for `g`, which has not yet been seen (since it is defined at line 4 of the input file), and thus proceed to evaluate the assertion with an empty model, thus raising an error because `f` is not defined in the model. Basically, interleaved mode requires the model to follow the same order as the input file when declaring/defining symbols.