### PR TITLE
Ensure stable error codes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,11 +2,20 @@
 next
 ----
 
+### UI
+
+- Ensure stability of error codes for the `dolmen` binary
+
 ### Parsing
 
 - Add `attrs` fields for all declarations and definition types,
   and correctly attach predicate attribute to individual definitions
   (PR#130)
+
+### Loop
+
+- Add possibility for users of the loop library to choose the
+  exit/return code for a `Code.t` (PR#134)
 
 
 v0.8.1

--- a/src/bin/options.ml
+++ b/src/bin/options.ml
@@ -13,6 +13,19 @@ let header_section = "HEADER CHECKING"
 let common_section = Manpage.s_options
 let profiling_section = "PROFILING"
 
+(* Initialise error codes *)
+(* ************************************************************************* *)
+
+let () =
+  Dolmen_loop.Code.init ~full:true [
+    Dolmen_loop.Code.generic, 1;
+    Dolmen_loop.Code.limit, 2;
+    Dolmen_loop.Code.parsing, 3;
+    Dolmen_loop.Code.typing, 4;
+    Dolmen_loop.Headers.code, 5;
+    Dolmen_model.Loop.code, 6;
+  ]
+
 (* Main commands *)
 (* ************************************************************************* *)
 

--- a/src/loop/code.ml
+++ b/src/loop/code.ml
@@ -34,15 +34,33 @@ let exit t =
 (* Manipulation *)
 (* ************************************************************************* *)
 
-let counter = ref 0
-let errors = ref []
+(* cmdliner uses codes 123, 124 and 125 *)
+let max_code = 122
+let all_codes = Array.make (max_code + 1) None
+
+let code_used code =
+  code <= 0 || code > max_code ||
+  match all_codes.(code) with
+  | Some _ -> true
+  | None -> false
+
+let find_code () =
+  let i = ref 1 in
+  while !i <= max_code && code_used !i do i := !i + 1 done;
+  if !i > max_code
+  then assert false (* no available error code *)
+  else !i
+
 
 (* The create function should only be used for error exit codes,
    the ok exit code (i.e. [0]) is create manually and not included
    in the errors list. *)
-let create ~category ~descr =
-  incr counter;
-  let code = !counter in
+let create ?code ~category ~descr () =
+  let code =
+    match code with
+    | Some c -> assert (not (code_used c)); c
+    | None -> find_code ()
+  in
   (* cmdliner uses retcode 124 for cli errors *)
   assert (0 < code && code < 124);
   let t = {
@@ -50,11 +68,18 @@ let create ~category ~descr =
     category;
     abort = false;
   } in
-  errors := t :: !errors;
+  all_codes.(code) <- Some t;
   t
 
 (*  *)
-let errors () = List.rev !errors
+let errors () =
+  let r = ref [] in
+  for i = Array.length all_codes - 1 downto 1 do
+    match all_codes.(i) with
+    | Some t -> r := t :: !r
+    | None -> ()
+  done;
+  !r
 
 (* Special values *)
 (* ************************************************************************* *)
@@ -77,19 +102,23 @@ let bug = {
 (* ************************************************************************* *)
 
 let generic =
-  create
+  create ()
+    ~code:1
     ~category:"Generic"
     ~descr:"on generic error"
 let limit =
-  create
+  create ()
+    ~code:2
     ~category:"Limits"
     ~descr:"upon reaching limits (time, memory, etc..)"
 let parsing =
-  create
+  create ()
+    ~code:3
     ~category:"Parsing"
     ~descr:"on parsing errors"
 let typing =
-  create
+  create ()
+    ~code:4
     ~category:"Typing"
     ~descr:"on typing errors"
 

--- a/src/loop/code.ml
+++ b/src/loop/code.ml
@@ -5,7 +5,9 @@
 (* ************************************************************************* *)
 
 type t = {
-  code : int; (* codes are unique for each exit code *)
+  mutable code : int;
+  (* codes are set later (to accomodate users of the lib choosing error codes
+     that do not conflict with theirs), and should be unique for each exit code *)
   descr : string;
   category : string;
   mutable abort : bool;
@@ -18,29 +20,18 @@ let compare t t' = compare t.code t'.code
 let descr t = t.code, t.descr
 let category t = t.category
 
-
-(* Exit with a code and code status *)
+(* Setting exact return codes *)
 (* ************************************************************************* *)
 
-let is_abort t = t.abort
-let abort t = t.abort <- true
-let error t = t.abort <- false
-
-let exit t =
-  if t.abort then Unix.kill (Unix.getpid ()) Sys.sigabrt;
-  exit t.code
-
-
-(* Manipulation *)
-(* ************************************************************************* *)
-
-(* cmdliner uses codes 123, 124 and 125 *)
+(* cmdliner uses codes 123, 124 and 125, and codes greater then 125 are
+   usually reserved for the shells. *)
 let max_code = 122
-let all_codes = Array.make (max_code + 1) None
+let all_errors = ref []
+let code_array = Array.make (max_code + 1) None
 
 let code_used code =
   code <= 0 || code > max_code ||
-  match all_codes.(code) with
+  match code_array.(code) with
   | Some _ -> true
   | None -> false
 
@@ -51,35 +42,57 @@ let find_code () =
   then assert false (* no available error code *)
   else !i
 
+let set_retcode (t, code) =
+  assert (t.code = -1);
+  assert (not (code_used code));
+  code_array.(code) <- Some t;
+  t.code <- code;
+  ()
+
+let init ?(full=false) l =
+  List.iter set_retcode l;
+  List.iter (fun t ->
+      if t.code < 0 then begin
+        if full then failwith "partial retcode init"
+        else begin
+          let code = find_code () in
+          set_retcode (t, code)
+        end
+      end) (List.rev !all_errors)
+
+
+(* Exit with a code and code status *)
+(* ************************************************************************* *)
+
+let is_abort t = t.abort
+let abort t = t.abort <- true
+let error t = t.abort <- false
+
+let exit t =
+  if t.code < 0 then failwith "missing retcode"
+  else if t.abort then (Unix.kill (Unix.getpid ()) Sys.sigabrt; assert false)
+  else exit t.code
+
+
+(* Manipulation *)
+(* ************************************************************************* *)
 
 (* The create function should only be used for error exit codes,
    the ok exit code (i.e. [0]) is create manually and not included
    in the errors list. *)
-let create ?code ~category ~descr () =
-  let code =
-    match code with
-    | Some c -> assert (not (code_used c)); c
-    | None -> find_code ()
-  in
-  (* cmdliner uses retcode 124 for cli errors *)
-  assert (0 < code && code < 124);
+let create ~category ~descr =
   let t = {
-    code; descr;
-    category;
+    code = -1;
     abort = false;
+    descr;
+    category;
   } in
-  all_codes.(code) <- Some t;
+  all_errors := t :: !all_errors;
   t
 
 (*  *)
 let errors () =
-  let r = ref [] in
-  for i = Array.length all_codes - 1 downto 1 do
-    match all_codes.(i) with
-    | Some t -> r := t :: !r
-    | None -> ()
-  done;
-  !r
+  List.rev !all_errors
 
 (* Special values *)
 (* ************************************************************************* *)
@@ -102,23 +115,19 @@ let bug = {
 (* ************************************************************************* *)
 
 let generic =
-  create ()
-    ~code:1
+  create
     ~category:"Generic"
     ~descr:"on generic error"
 let limit =
-  create ()
-    ~code:2
+  create
     ~category:"Limits"
     ~descr:"upon reaching limits (time, memory, etc..)"
 let parsing =
-  create ()
-    ~code:3
+  create
     ~category:"Parsing"
     ~descr:"on parsing errors"
 let typing =
-  create ()
-    ~code:4
+  create
     ~category:"Typing"
     ~descr:"on typing errors"
 

--- a/src/loop/code.mli
+++ b/src/loop/code.mli
@@ -13,7 +13,11 @@ val compare : t -> t -> int
 
 (** {2 Manipulating error codes} *)
 
-val create : ?code:int -> category:string -> descr:string -> unit -> t
+val init : ?full:bool -> (t * int) list -> unit
+(** Initialise all retcodes, automatically choosing one for those not
+    in the provided list. *)
+
+val create : category:string -> descr:string -> t
 (** Create a new exit code. The string given is used as a description
     for the exit code. The create code is active by default. *)
 

--- a/src/loop/code.mli
+++ b/src/loop/code.mli
@@ -4,7 +4,7 @@
 (** {2 Exit codes} *)
 
 type t
-(** An exit code, i.e. an integer between 0 and 126. *)
+(** An exit code, i.e. an integer between 0 and 126, along with some additional info. *)
 
 val hash : t -> int
 val equal : t -> t -> bool
@@ -13,7 +13,7 @@ val compare : t -> t -> int
 
 (** {2 Manipulating error codes} *)
 
-val create : category:string -> descr:string -> t
+val create : ?code:int -> category:string -> descr:string -> unit -> t
 (** Create a new exit code. The string given is used as a description
     for the exit code. The create code is active by default. *)
 

--- a/src/loop/code.mli
+++ b/src/loop/code.mli
@@ -4,18 +4,29 @@
 (** {2 Exit codes} *)
 
 type t
-(** An exit code, i.e. an integer between 0 and 126, along with some additional info. *)
+(** An abstraction over exit status.
+
+    Concretely this corresponds to an exit/return code for the binary (in the case of
+    the dolmen binary or solver-like binaries).
+
+    In practice, the exact error code corresponding to a value of this type can be set
+    later. This is useful so that users of the library can decide the codes, and among
+    other things, ensure that error codes are stable. *)
 
 val hash : t -> int
 val equal : t -> t -> bool
 val compare : t -> t -> int
+(** Usual functions *)
 
 
 (** {2 Manipulating error codes} *)
 
 val init : ?full:bool -> (t * int) list -> unit
-(** Initialise all retcodes, automatically choosing one for those not
-    in the provided list. *)
+(** Initialise all retcodes with the given association list.
+    All codes that are not present in the list are assigned a arbitrary
+    free return code.
+    If [~full] is [true], and not all retcodes are present in the association
+    list, then this function with raise a [Failure _] exception. *)
 
 val create : category:string -> descr:string -> t
 (** Create a new exit code. The string given is used as a description
@@ -62,9 +73,8 @@ val typing : t
 (** {2 Exit code status} *)
 
 val exit : t -> _
-(** Exit with the given code.
-    Note: exit codes can be silenced, in which case the process
-    will exit with an exit code of [0]. *)
+(** Exit with the given code (or abort if the exit code is marked as
+    an abort code). *)
 
 val is_abort : t -> bool
 (** Whether an exit code is active. *)

--- a/src/loop/headers.ml
+++ b/src/loop/headers.ml
@@ -173,8 +173,7 @@ end
 (* ************************************************************************ *)
 
 let code =
-  Code.create ()
-    ~code:5
+  Code.create
     ~category:"Header"
     ~descr:"on header errors"
 

--- a/src/loop/headers.ml
+++ b/src/loop/headers.ml
@@ -173,7 +173,8 @@ end
 (* ************************************************************************ *)
 
 let code =
-  Code.create
+  Code.create ()
+    ~code:5
     ~category:"Header"
     ~descr:"on header errors"
 

--- a/src/loop/headers.mli
+++ b/src/loop/headers.mli
@@ -49,6 +49,9 @@ val remove : t -> Field.t -> t
 
 (** {2 Pipe functor} *)
 
+val code : Code.t
+(** Code for header errors. *)
+
 module type S = Headers_intf.S
 
 module Make(S : State.S) : S with type state := S.t

--- a/src/model/loop.ml
+++ b/src/model/loop.ml
@@ -65,8 +65,7 @@ let pp_wrap pp fmt x =
   Format.fprintf fmt "`%a`" pp x
 
 let code =
-  Dolmen_loop.Code.create ()
-    ~code:6
+  Dolmen_loop.Code.create
     ~category:"Model"
     ~descr:"on model verification errors"
 

--- a/src/model/loop.ml
+++ b/src/model/loop.ml
@@ -64,7 +64,9 @@ let empty ~mode () = {
 let pp_wrap pp fmt x =
   Format.fprintf fmt "`%a`" pp x
 
-let code = Dolmen_loop.Code.create
+let code =
+  Dolmen_loop.Code.create ()
+    ~code:6
     ~category:"Model"
     ~descr:"on model verification errors"
 


### PR DESCRIPTION
Ensure the stability of dolmen error codes (since they may be used by scripts to discriminate on the kind of error).