### PR TITLE
Fix comparison of abstract array values

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -37,6 +37,7 @@ next
   would raise an internal error (PR#138)
 - Remove the "error" keyword and statement from smtlib2
   response (model) files (PR#139)
+- Correctly compare abstract array values (PR#143)
 
 v0.8.1
 ------

--- a/src/model/array.ml
+++ b/src/model/array.ml
@@ -11,26 +11,32 @@ let (<?>) = Dolmen.Std.Misc.(<?>)
 module E = Dolmen.Std.Expr
 module B = Dolmen.Std.Builtin
 
+type base =
+  | Const of Value.t
+  | Abstract of E.Term.Const.t
+
 type t = {
-  base : Value.t option;
+  base : base;
   map : Value.t Value.Map.t;
 }
-(* invariant : none of the keys in the map binds to the [base] value *)
+(* invariant : none of the keys in the map binds to the [Const] value of
+   [base] if it is not abstract. *)
 
 (* abstract arrays, as defined in the smtlib standard
    NOTE: to make cvc5 output models using abstract values, use the
          `--abstract-values` option
 *)
-let abstract = {
-  base = None;
+let abstract cst = {
+  base = Abstract cst;
   map = Value.Map.empty;
 }
 
 (* Printing functions *)
 let print_base fmt = function
-  | None -> ()
-  | Some base ->
+  | Const base ->
     Format.fprintf fmt "_ -> %a;@ " Value.print base
+  | Abstract cst ->
+    Format.fprintf fmt "%a;@ " E.Term.Const.print cst
 
 let print_map fmt map =
   Value.Map.iter (fun key value ->
@@ -45,10 +51,10 @@ let print fmt { map; base; } =
 (* Comparison *)
 let compare_base base base' =
   match base, base' with
-  | None, None -> 0
-  | Some _, None -> -1
-  | None, Some _ -> 1
-  | Some v, Some v' -> Value.compare v v'
+  | Abstract cst, Abstract cst' -> E.Term.Const.compare cst cst'
+  | Const _, Abstract _ -> -1
+  | Abstract _, Const _ -> 1
+  | Const v, Const v' -> Value.compare v v'
 
 let compare_map map map' =
   Value.Map.compare Value.compare map map'
@@ -65,7 +71,7 @@ let ops = Value.ops ~abstract ~print ~compare ()
 (* ************************************************************************* *)
 
 let const base =
-  Value.mk ~ops { map = Value.Map.empty; base = Some base; }
+  Value.mk ~ops { map = Value.Map.empty; base = Const base; }
 
 let select array key =
   let { map; base; } = Value.extract_exn ~ops array in
@@ -73,16 +79,16 @@ let select array key =
   | Some res -> res
   | None ->
     begin match base with
-      | Some res -> res
-      | None -> raise Eval.Partial_model
+      | Const res -> res
+      | Abstract _ -> raise Eval.Partial_model
     end
 
 let store array key value =
   let { map; base; } = Value.extract_exn ~ops array in
   let map' =
     match base with
-    | None -> Value.Map.add key value map
-    | Some base ->
+    | Abstract _ -> Value.Map.add key value map
+    | Const base ->
       if Value.compare value base = 0 then
         Value.Map.remove key map
       else

--- a/src/model/value.mli
+++ b/src/model/value.mli
@@ -26,7 +26,7 @@ val abstract_cst : Dolmen.Std.Expr.Term.Const.t -> t
 (** ************************************************************************ *)
 
 val ops :
-  ?abstract:'a ->
+  ?abstract:(Dolmen.Std.Expr.Term.Const.t -> 'a) ->
   compare:('a -> 'a -> int) ->
   print:(Format.formatter -> 'a -> unit) ->
   unit -> 'a ops

--- a/tests/model/array/comparison_abstract.rsmt2
+++ b/tests/model/array/comparison_abstract.rsmt2
@@ -1,0 +1,9 @@
+sat
+(
+(define-fun a () (Array Int Int)
+  (store (as @arr0 (Array Int Int)) 0 0))
+(define-fun b () (Array Int Int)
+  (store (as @arr0 (Array Int Int)) 0 0))
+(define-fun c () (Array Int Int)
+  (store (as @arr1 (Array Int Int)) 0 0))
+)

--- a/tests/model/array/comparison_abstract.smt2
+++ b/tests/model/array/comparison_abstract.smt2
@@ -1,0 +1,8 @@
+(set-logic ALL)
+
+(declare-fun a () (Array Int Int))
+(declare-fun b () (Array Int Int))
+(declare-fun c () (Array Int Int))
+(assert (= a b))
+(assert (not (= a c)))
+(check-sat)

--- a/tests/model/array/dune
+++ b/tests/model/array/dune
@@ -65,4 +65,38 @@
   (action (diff array_const.expected array_const.full)))
 
 
+; Test for comparison_abstract.smt2
+; Incremental test
+
+(rule
+   (target  comparison_abstract.incremental)
+   (deps    (:response comparison_abstract.rsmt2)
+            (:input comparison_abstract.smt2))
+   (package dolmen_bin)
+   (action (chdir %{workspace_root}
+            (with-outputs-to %{target}
+             (with-accepted-exit-codes (or 0 (not 0))
+              (run dolmen --check-model=true -r %{response} --mode=incremental --color=never %{input} %{read-lines:flags.dune}))))))
+(rule
+  (alias runtest)
+  (package dolmen_bin)
+  (action (diff comparison_abstract.expected comparison_abstract.incremental)))
+
+; Full mode test
+
+(rule
+   (target  comparison_abstract.full)
+   (deps    (:response comparison_abstract.rsmt2)
+            (:input comparison_abstract.smt2))
+   (package dolmen_bin)
+   (action (chdir %{workspace_root}
+            (with-outputs-to %{target}
+             (with-accepted-exit-codes (or 0 (not 0))
+              (run dolmen --check-model=true -r %{response} --mode=full --color=never %{input} %{read-lines:flags.dune}))))))
+(rule
+  (alias runtest)
+  (package dolmen_bin)
+  (action (diff comparison_abstract.expected comparison_abstract.full)))
+
+
 ; Auto-generated part end


### PR DESCRIPTION
Previously, the code treated all array abstract values as equal, with this, we now consider two abstract values equal iff they are the same constant.