### PR TITLE
Re-enable support for "and" inside function/predicate

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,6 +19,9 @@ next
   and correctly attach predicate attribute to individual definitions
   (PR#130)
 
+- Restore support for toplevel "and" in non-recursive predicate/function
+  definitions (PR #147, fixes issue #144)
+
 ### Typing
 
 - Ignore arithmetic restrictions when typing model values. This

--- a/src/languages/ae/parser.mly
+++ b/src/languages/ae/parser.mly
@@ -516,14 +516,14 @@ rewriting_list:
   | e=lexpr PV l=rewriting_list
     { e :: l }
 
-function_def:
+%inline function_def:
   | FUNC f=raw_named_ident
     LEFTPAR args=separated_list(COMMA, logic_binder) RIGHTPAR
     COLON ret_ty=primitive_type EQUAL body=lexpr
     { let loc = L.mk_pos $startpos $endpos in
       S.fun_def ~loc f [] args ret_ty body }
 
-predicate_def:
+%inline predicate_def:
   | PRED p=raw_named_ident EQUAL body=lexpr
     { let loc = L.mk_pos $startpos $endpos in
       S.pred_def ~loc p [] [] body }
@@ -533,7 +533,7 @@ predicate_def:
     { let loc = L.mk_pos $startpos $endpos in
       S.pred_def ~loc p [] args body }
 
-function_or_predicate_def:
+%inline function_or_predicate_def:
   | s=function_def
   | s=predicate_def
     { s }

--- a/src/languages/ae/syntax.messages
+++ b/src/languages/ae/syntax.messages
@@ -3369,8 +3369,10 @@ file: PRED XOR
 ##
 ## Ends in an error in state: 308.
 ##
-## predicate_def -> PRED . raw_named_ident EQUAL lexpr [ TYPE THEORY REWRITING PRED LOGIC GOAL FUNC EOF AXIOM AND ]
-## predicate_def -> PRED . raw_named_ident LEFTPAR loption(separated_nonempty_list(COMMA,logic_binder)) RIGHTPAR EQUAL lexpr [ TYPE THEORY REWRITING PRED LOGIC GOAL FUNC EOF AXIOM AND ]
+## separated_nonempty_list(AND,function_or_predicate_def) -> PRED . raw_named_ident EQUAL lexpr [ TYPE THEORY REWRITING PRED LOGIC GOAL FUNC EOF AXIOM ]
+## separated_nonempty_list(AND,function_or_predicate_def) -> PRED . raw_named_ident LEFTPAR loption(separated_nonempty_list(COMMA,logic_binder)) RIGHTPAR EQUAL lexpr [ TYPE THEORY REWRITING PRED LOGIC GOAL FUNC EOF AXIOM ]
+## separated_nonempty_list(AND,function_or_predicate_def) -> PRED . raw_named_ident EQUAL lexpr AND separated_nonempty_list(AND,function_or_predicate_def) [ TYPE THEORY REWRITING PRED LOGIC GOAL FUNC EOF AXIOM ]
+## separated_nonempty_list(AND,function_or_predicate_def) -> PRED . raw_named_ident LEFTPAR loption(separated_nonempty_list(COMMA,logic_binder)) RIGHTPAR EQUAL lexpr AND separated_nonempty_list(AND,function_or_predicate_def) [ TYPE THEORY REWRITING PRED LOGIC GOAL FUNC EOF AXIOM ]
 ##
 ## The known suffix of the stack is as follows:
 ## PRED
@@ -3382,8 +3384,10 @@ file: PRED ID COMMA
 ##
 ## Ends in an error in state: 309.
 ##
-## predicate_def -> PRED raw_named_ident . EQUAL lexpr [ TYPE THEORY REWRITING PRED LOGIC GOAL FUNC EOF AXIOM AND ]
-## predicate_def -> PRED raw_named_ident . LEFTPAR loption(separated_nonempty_list(COMMA,logic_binder)) RIGHTPAR EQUAL lexpr [ TYPE THEORY REWRITING PRED LOGIC GOAL FUNC EOF AXIOM AND ]
+## separated_nonempty_list(AND,function_or_predicate_def) -> PRED raw_named_ident . EQUAL lexpr [ TYPE THEORY REWRITING PRED LOGIC GOAL FUNC EOF AXIOM ]
+## separated_nonempty_list(AND,function_or_predicate_def) -> PRED raw_named_ident . LEFTPAR loption(separated_nonempty_list(COMMA,logic_binder)) RIGHTPAR EQUAL lexpr [ TYPE THEORY REWRITING PRED LOGIC GOAL FUNC EOF AXIOM ]
+## separated_nonempty_list(AND,function_or_predicate_def) -> PRED raw_named_ident . EQUAL lexpr AND separated_nonempty_list(AND,function_or_predicate_def) [ TYPE THEORY REWRITING PRED LOGIC GOAL FUNC EOF AXIOM ]
+## separated_nonempty_list(AND,function_or_predicate_def) -> PRED raw_named_ident . LEFTPAR loption(separated_nonempty_list(COMMA,logic_binder)) RIGHTPAR EQUAL lexpr AND separated_nonempty_list(AND,function_or_predicate_def) [ TYPE THEORY REWRITING PRED LOGIC GOAL FUNC EOF AXIOM ]
 ##
 ## The known suffix of the stack is as follows:
 ## PRED raw_named_ident
@@ -3401,7 +3405,8 @@ file: PRED ID LEFTPAR XOR
 ##
 ## Ends in an error in state: 310.
 ##
-## predicate_def -> PRED raw_named_ident LEFTPAR . loption(separated_nonempty_list(COMMA,logic_binder)) RIGHTPAR EQUAL lexpr [ TYPE THEORY REWRITING PRED LOGIC GOAL FUNC EOF AXIOM AND ]
+## separated_nonempty_list(AND,function_or_predicate_def) -> PRED raw_named_ident LEFTPAR . loption(separated_nonempty_list(COMMA,logic_binder)) RIGHTPAR EQUAL lexpr [ TYPE THEORY REWRITING PRED LOGIC GOAL FUNC EOF AXIOM ]
+## separated_nonempty_list(AND,function_or_predicate_def) -> PRED raw_named_ident LEFTPAR . loption(separated_nonempty_list(COMMA,logic_binder)) RIGHTPAR EQUAL lexpr AND separated_nonempty_list(AND,function_or_predicate_def) [ TYPE THEORY REWRITING PRED LOGIC GOAL FUNC EOF AXIOM ]
 ##
 ## The known suffix of the stack is as follows:
 ## PRED raw_named_ident LEFTPAR
@@ -3413,7 +3418,8 @@ file: PRED ID LEFTPAR RIGHTPAR XOR
 ##
 ## Ends in an error in state: 313.
 ##
-## predicate_def -> PRED raw_named_ident LEFTPAR loption(separated_nonempty_list(COMMA,logic_binder)) RIGHTPAR . EQUAL lexpr [ TYPE THEORY REWRITING PRED LOGIC GOAL FUNC EOF AXIOM AND ]
+## separated_nonempty_list(AND,function_or_predicate_def) -> PRED raw_named_ident LEFTPAR loption(separated_nonempty_list(COMMA,logic_binder)) RIGHTPAR . EQUAL lexpr [ TYPE THEORY REWRITING PRED LOGIC GOAL FUNC EOF AXIOM ]
+## separated_nonempty_list(AND,function_or_predicate_def) -> PRED raw_named_ident LEFTPAR loption(separated_nonempty_list(COMMA,logic_binder)) RIGHTPAR . EQUAL lexpr AND separated_nonempty_list(AND,function_or_predicate_def) [ TYPE THEORY REWRITING PRED LOGIC GOAL FUNC EOF AXIOM ]
 ##
 ## The known suffix of the stack is as follows:
 ## PRED raw_named_ident LEFTPAR loption(separated_nonempty_list(COMMA,logic_binder)) RIGHTPAR
@@ -3425,7 +3431,8 @@ file: PRED ID LEFTPAR RIGHTPAR EQUAL XOR
 ##
 ## Ends in an error in state: 314.
 ##
-## predicate_def -> PRED raw_named_ident LEFTPAR loption(separated_nonempty_list(COMMA,logic_binder)) RIGHTPAR EQUAL . lexpr [ TYPE THEORY REWRITING PRED LOGIC GOAL FUNC EOF AXIOM AND ]
+## separated_nonempty_list(AND,function_or_predicate_def) -> PRED raw_named_ident LEFTPAR loption(separated_nonempty_list(COMMA,logic_binder)) RIGHTPAR EQUAL . lexpr [ TYPE THEORY REWRITING PRED LOGIC GOAL FUNC EOF AXIOM ]
+## separated_nonempty_list(AND,function_or_predicate_def) -> PRED raw_named_ident LEFTPAR loption(separated_nonempty_list(COMMA,logic_binder)) RIGHTPAR EQUAL . lexpr AND separated_nonempty_list(AND,function_or_predicate_def) [ TYPE THEORY REWRITING PRED LOGIC GOAL FUNC EOF AXIOM ]
 ##
 ## The known suffix of the stack is as follows:
 ## PRED raw_named_ident LEFTPAR loption(separated_nonempty_list(COMMA,logic_binder)) RIGHTPAR EQUAL
@@ -3457,7 +3464,8 @@ file: PRED ID LEFTPAR RIGHTPAR EQUAL ID RIGHTSQ
 ## lexpr -> lexpr . NOTEQ lexpr [ XOR TYPE TIMES THEORY SLASH RIGHTARROW REWRITING PRED POWDOT POW PLUS PERCENT OR NOTEQ MINUS LT LRARROW LOGIC LE HAT GT GOAL GE FUNC EQUAL EOF AXIOM AT AND ]
 ## lexpr -> lexpr . HAT LEFTBR INTEGER COMMA INTEGER RIGHTBR [ XOR TYPE TIMES THEORY SLASH RIGHTARROW REWRITING PRED POWDOT POW PLUS PERCENT OR NOTEQ MINUS LT LRARROW LOGIC LE HAT GT GOAL GE FUNC EQUAL EOF AXIOM AT AND ]
 ## lexpr -> lexpr . AT lexpr [ XOR TYPE TIMES THEORY SLASH RIGHTARROW REWRITING PRED POWDOT POW PLUS PERCENT OR NOTEQ MINUS LT LRARROW LOGIC LE HAT GT GOAL GE FUNC EQUAL EOF AXIOM AT AND ]
-## predicate_def -> PRED raw_named_ident LEFTPAR loption(separated_nonempty_list(COMMA,logic_binder)) RIGHTPAR EQUAL lexpr . [ TYPE THEORY REWRITING PRED LOGIC GOAL FUNC EOF AXIOM AND ]
+## separated_nonempty_list(AND,function_or_predicate_def) -> PRED raw_named_ident LEFTPAR loption(separated_nonempty_list(COMMA,logic_binder)) RIGHTPAR EQUAL lexpr . [ TYPE THEORY REWRITING PRED LOGIC GOAL FUNC EOF AXIOM ]
+## separated_nonempty_list(AND,function_or_predicate_def) -> PRED raw_named_ident LEFTPAR loption(separated_nonempty_list(COMMA,logic_binder)) RIGHTPAR EQUAL lexpr . AND separated_nonempty_list(AND,function_or_predicate_def) [ TYPE THEORY REWRITING PRED LOGIC GOAL FUNC EOF AXIOM ]
 ##
 ## The known suffix of the stack is as follows:
 ## PRED raw_named_ident LEFTPAR loption(separated_nonempty_list(COMMA,logic_binder)) RIGHTPAR EQUAL lexpr
@@ -3472,70 +3480,120 @@ file: PRED ID LEFTPAR RIGHTPAR EQUAL ID RIGHTSQ
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
-file: FUNC ID LEFTPAR ID COLON ID COMMA XOR
+file: PRED ID LEFTPAR RIGHTPAR EQUAL ID AND XOR
+##
+## Ends in an error in state: 316.
+##
+## lexpr -> lexpr AND . lexpr [ XOR TYPE TIMES THEORY SLASH RIGHTARROW REWRITING PRED POWDOT POW PLUS PERCENT OR NOTEQ MINUS LT LRARROW LOGIC LE HAT GT GOAL GE FUNC EQUAL EOF AXIOM AT AND ]
+## separated_nonempty_list(AND,function_or_predicate_def) -> PRED raw_named_ident LEFTPAR loption(separated_nonempty_list(COMMA,logic_binder)) RIGHTPAR EQUAL lexpr AND . separated_nonempty_list(AND,function_or_predicate_def) [ TYPE THEORY REWRITING PRED LOGIC GOAL FUNC EOF AXIOM ]
+##
+## The known suffix of the stack is as follows:
+## PRED raw_named_ident LEFTPAR loption(separated_nonempty_list(COMMA,logic_binder)) RIGHTPAR EQUAL lexpr AND
+##
+
+<YOUR SYNTAX ERROR MESSAGE HERE>
+
+file: FUNC XOR
 ##
 ## Ends in an error in state: 317.
 ##
-## separated_nonempty_list(COMMA,logic_binder) -> logic_binder COMMA . separated_nonempty_list(COMMA,logic_binder) [ RIGHTPAR ]
+## separated_nonempty_list(AND,function_or_predicate_def) -> FUNC . raw_named_ident LEFTPAR loption(separated_nonempty_list(COMMA,logic_binder)) RIGHTPAR COLON primitive_type EQUAL lexpr [ TYPE THEORY REWRITING PRED LOGIC GOAL FUNC EOF AXIOM ]
+## separated_nonempty_list(AND,function_or_predicate_def) -> FUNC . raw_named_ident LEFTPAR loption(separated_nonempty_list(COMMA,logic_binder)) RIGHTPAR COLON primitive_type EQUAL lexpr AND separated_nonempty_list(AND,function_or_predicate_def) [ TYPE THEORY REWRITING PRED LOGIC GOAL FUNC EOF AXIOM ]
 ##
 ## The known suffix of the stack is as follows:
-## logic_binder COMMA
+## FUNC
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
-file: FUNC ID LEFTPAR ID XOR
+file: FUNC ID EQUAL
+##
+## Ends in an error in state: 318.
+##
+## separated_nonempty_list(AND,function_or_predicate_def) -> FUNC raw_named_ident . LEFTPAR loption(separated_nonempty_list(COMMA,logic_binder)) RIGHTPAR COLON primitive_type EQUAL lexpr [ TYPE THEORY REWRITING PRED LOGIC GOAL FUNC EOF AXIOM ]
+## separated_nonempty_list(AND,function_or_predicate_def) -> FUNC raw_named_ident . LEFTPAR loption(separated_nonempty_list(COMMA,logic_binder)) RIGHTPAR COLON primitive_type EQUAL lexpr AND separated_nonempty_list(AND,function_or_predicate_def) [ TYPE THEORY REWRITING PRED LOGIC GOAL FUNC EOF AXIOM ]
+##
+## The known suffix of the stack is as follows:
+## FUNC raw_named_ident
+##
+## WARNING: This example involves spurious reductions.
+## This implies that, although the LR(1) items shown above provide an
+## accurate view of the past (what has been recognized so far), they
+## may provide an INCOMPLETE view of the future (what was expected next).
+## In state 109, spurious reduction of production raw_named_ident -> ID
+##
+
+<YOUR SYNTAX ERROR MESSAGE HERE>
+
+file: FUNC ID LEFTPAR XOR
 ##
 ## Ends in an error in state: 319.
 ##
-## logic_binder -> ident . COLON primitive_type [ RIGHTPAR COMMA ]
+## separated_nonempty_list(AND,function_or_predicate_def) -> FUNC raw_named_ident LEFTPAR . loption(separated_nonempty_list(COMMA,logic_binder)) RIGHTPAR COLON primitive_type EQUAL lexpr [ TYPE THEORY REWRITING PRED LOGIC GOAL FUNC EOF AXIOM ]
+## separated_nonempty_list(AND,function_or_predicate_def) -> FUNC raw_named_ident LEFTPAR . loption(separated_nonempty_list(COMMA,logic_binder)) RIGHTPAR COLON primitive_type EQUAL lexpr AND separated_nonempty_list(AND,function_or_predicate_def) [ TYPE THEORY REWRITING PRED LOGIC GOAL FUNC EOF AXIOM ]
 ##
 ## The known suffix of the stack is as follows:
-## ident
+## FUNC raw_named_ident LEFTPAR
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
-file: FUNC ID LEFTPAR ID COLON XOR
-##
-## Ends in an error in state: 320.
-##
-## logic_binder -> ident COLON . primitive_type [ RIGHTPAR COMMA ]
-##
-## The known suffix of the stack is as follows:
-## ident COLON
-##
-
-<YOUR SYNTAX ERROR MESSAGE HERE>
-
-file: FUNC ID LEFTPAR ID COLON ID XOR
+file: FUNC ID LEFTPAR RIGHTPAR XOR
 ##
 ## Ends in an error in state: 321.
 ##
-## logic_binder -> ident COLON primitive_type . [ RIGHTPAR COMMA ]
-## primitive_type -> primitive_type . ty_ident [ RIGHTPAR ID COMMA ]
+## separated_nonempty_list(AND,function_or_predicate_def) -> FUNC raw_named_ident LEFTPAR loption(separated_nonempty_list(COMMA,logic_binder)) RIGHTPAR . COLON primitive_type EQUAL lexpr [ TYPE THEORY REWRITING PRED LOGIC GOAL FUNC EOF AXIOM ]
+## separated_nonempty_list(AND,function_or_predicate_def) -> FUNC raw_named_ident LEFTPAR loption(separated_nonempty_list(COMMA,logic_binder)) RIGHTPAR . COLON primitive_type EQUAL lexpr AND separated_nonempty_list(AND,function_or_predicate_def) [ TYPE THEORY REWRITING PRED LOGIC GOAL FUNC EOF AXIOM ]
 ##
 ## The known suffix of the stack is as follows:
-## ident COLON primitive_type
+## FUNC raw_named_ident LEFTPAR loption(separated_nonempty_list(COMMA,logic_binder)) RIGHTPAR
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
-file: PRED ID EQUAL XOR
+file: FUNC ID LEFTPAR RIGHTPAR COLON XOR
 ##
 ## Ends in an error in state: 322.
 ##
-## predicate_def -> PRED raw_named_ident EQUAL . lexpr [ TYPE THEORY REWRITING PRED LOGIC GOAL FUNC EOF AXIOM AND ]
+## separated_nonempty_list(AND,function_or_predicate_def) -> FUNC raw_named_ident LEFTPAR loption(separated_nonempty_list(COMMA,logic_binder)) RIGHTPAR COLON . primitive_type EQUAL lexpr [ TYPE THEORY REWRITING PRED LOGIC GOAL FUNC EOF AXIOM ]
+## separated_nonempty_list(AND,function_or_predicate_def) -> FUNC raw_named_ident LEFTPAR loption(separated_nonempty_list(COMMA,logic_binder)) RIGHTPAR COLON . primitive_type EQUAL lexpr AND separated_nonempty_list(AND,function_or_predicate_def) [ TYPE THEORY REWRITING PRED LOGIC GOAL FUNC EOF AXIOM ]
 ##
 ## The known suffix of the stack is as follows:
-## PRED raw_named_ident EQUAL
+## FUNC raw_named_ident LEFTPAR loption(separated_nonempty_list(COMMA,logic_binder)) RIGHTPAR COLON
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
-file: PRED ID EQUAL ID RIGHTSQ
+file: FUNC ID LEFTPAR RIGHTPAR COLON ID XOR
 ##
 ## Ends in an error in state: 323.
+##
+## primitive_type -> primitive_type . ty_ident [ ID EQUAL ]
+## separated_nonempty_list(AND,function_or_predicate_def) -> FUNC raw_named_ident LEFTPAR loption(separated_nonempty_list(COMMA,logic_binder)) RIGHTPAR COLON primitive_type . EQUAL lexpr [ TYPE THEORY REWRITING PRED LOGIC GOAL FUNC EOF AXIOM ]
+## separated_nonempty_list(AND,function_or_predicate_def) -> FUNC raw_named_ident LEFTPAR loption(separated_nonempty_list(COMMA,logic_binder)) RIGHTPAR COLON primitive_type . EQUAL lexpr AND separated_nonempty_list(AND,function_or_predicate_def) [ TYPE THEORY REWRITING PRED LOGIC GOAL FUNC EOF AXIOM ]
+##
+## The known suffix of the stack is as follows:
+## FUNC raw_named_ident LEFTPAR loption(separated_nonempty_list(COMMA,logic_binder)) RIGHTPAR COLON primitive_type
+##
+
+<YOUR SYNTAX ERROR MESSAGE HERE>
+
+file: FUNC ID LEFTPAR RIGHTPAR COLON ID EQUAL XOR
+##
+## Ends in an error in state: 324.
+##
+## separated_nonempty_list(AND,function_or_predicate_def) -> FUNC raw_named_ident LEFTPAR loption(separated_nonempty_list(COMMA,logic_binder)) RIGHTPAR COLON primitive_type EQUAL . lexpr [ TYPE THEORY REWRITING PRED LOGIC GOAL FUNC EOF AXIOM ]
+## separated_nonempty_list(AND,function_or_predicate_def) -> FUNC raw_named_ident LEFTPAR loption(separated_nonempty_list(COMMA,logic_binder)) RIGHTPAR COLON primitive_type EQUAL . lexpr AND separated_nonempty_list(AND,function_or_predicate_def) [ TYPE THEORY REWRITING PRED LOGIC GOAL FUNC EOF AXIOM ]
+##
+## The known suffix of the stack is as follows:
+## FUNC raw_named_ident LEFTPAR loption(separated_nonempty_list(COMMA,logic_binder)) RIGHTPAR COLON primitive_type EQUAL
+##
+
+<YOUR SYNTAX ERROR MESSAGE HERE>
+
+file: FUNC ID LEFTPAR RIGHTPAR COLON ID EQUAL ID RIGHTSQ
+##
+## Ends in an error in state: 325.
 ##
 ## lexpr -> lexpr . PLUS lexpr [ XOR TYPE TIMES THEORY SLASH RIGHTARROW REWRITING PRED POWDOT POW PLUS PERCENT OR NOTEQ MINUS LT LRARROW LOGIC LE HAT GT GOAL GE FUNC EQUAL EOF AXIOM AT AND ]
 ## lexpr -> lexpr . MINUS lexpr [ XOR TYPE TIMES THEORY SLASH RIGHTARROW REWRITING PRED POWDOT POW PLUS PERCENT OR NOTEQ MINUS LT LRARROW LOGIC LE HAT GT GOAL GE FUNC EQUAL EOF AXIOM AT AND ]
@@ -3557,7 +3615,123 @@ file: PRED ID EQUAL ID RIGHTSQ
 ## lexpr -> lexpr . NOTEQ lexpr [ XOR TYPE TIMES THEORY SLASH RIGHTARROW REWRITING PRED POWDOT POW PLUS PERCENT OR NOTEQ MINUS LT LRARROW LOGIC LE HAT GT GOAL GE FUNC EQUAL EOF AXIOM AT AND ]
 ## lexpr -> lexpr . HAT LEFTBR INTEGER COMMA INTEGER RIGHTBR [ XOR TYPE TIMES THEORY SLASH RIGHTARROW REWRITING PRED POWDOT POW PLUS PERCENT OR NOTEQ MINUS LT LRARROW LOGIC LE HAT GT GOAL GE FUNC EQUAL EOF AXIOM AT AND ]
 ## lexpr -> lexpr . AT lexpr [ XOR TYPE TIMES THEORY SLASH RIGHTARROW REWRITING PRED POWDOT POW PLUS PERCENT OR NOTEQ MINUS LT LRARROW LOGIC LE HAT GT GOAL GE FUNC EQUAL EOF AXIOM AT AND ]
-## predicate_def -> PRED raw_named_ident EQUAL lexpr . [ TYPE THEORY REWRITING PRED LOGIC GOAL FUNC EOF AXIOM AND ]
+## separated_nonempty_list(AND,function_or_predicate_def) -> FUNC raw_named_ident LEFTPAR loption(separated_nonempty_list(COMMA,logic_binder)) RIGHTPAR COLON primitive_type EQUAL lexpr . [ TYPE THEORY REWRITING PRED LOGIC GOAL FUNC EOF AXIOM ]
+## separated_nonempty_list(AND,function_or_predicate_def) -> FUNC raw_named_ident LEFTPAR loption(separated_nonempty_list(COMMA,logic_binder)) RIGHTPAR COLON primitive_type EQUAL lexpr . AND separated_nonempty_list(AND,function_or_predicate_def) [ TYPE THEORY REWRITING PRED LOGIC GOAL FUNC EOF AXIOM ]
+##
+## The known suffix of the stack is as follows:
+## FUNC raw_named_ident LEFTPAR loption(separated_nonempty_list(COMMA,logic_binder)) RIGHTPAR COLON primitive_type EQUAL lexpr
+##
+## WARNING: This example involves spurious reductions.
+## This implies that, although the LR(1) items shown above provide an
+## accurate view of the past (what has been recognized so far), they
+## may provide an INCOMPLETE view of the future (what was expected next).
+## In state 144, spurious reduction of production simple_expr -> ident
+## In state 124, spurious reduction of production lexpr -> simple_expr
+##
+
+<YOUR SYNTAX ERROR MESSAGE HERE>
+
+file: FUNC ID LEFTPAR RIGHTPAR COLON ID EQUAL ID AND XOR
+##
+## Ends in an error in state: 326.
+##
+## lexpr -> lexpr AND . lexpr [ XOR TYPE TIMES THEORY SLASH RIGHTARROW REWRITING PRED POWDOT POW PLUS PERCENT OR NOTEQ MINUS LT LRARROW LOGIC LE HAT GT GOAL GE FUNC EQUAL EOF AXIOM AT AND ]
+## separated_nonempty_list(AND,function_or_predicate_def) -> FUNC raw_named_ident LEFTPAR loption(separated_nonempty_list(COMMA,logic_binder)) RIGHTPAR COLON primitive_type EQUAL lexpr AND . separated_nonempty_list(AND,function_or_predicate_def) [ TYPE THEORY REWRITING PRED LOGIC GOAL FUNC EOF AXIOM ]
+##
+## The known suffix of the stack is as follows:
+## FUNC raw_named_ident LEFTPAR loption(separated_nonempty_list(COMMA,logic_binder)) RIGHTPAR COLON primitive_type EQUAL lexpr AND
+##
+
+<YOUR SYNTAX ERROR MESSAGE HERE>
+
+file: FUNC ID LEFTPAR ID COLON ID COMMA XOR
+##
+## Ends in an error in state: 329.
+##
+## separated_nonempty_list(COMMA,logic_binder) -> logic_binder COMMA . separated_nonempty_list(COMMA,logic_binder) [ RIGHTPAR ]
+##
+## The known suffix of the stack is as follows:
+## logic_binder COMMA
+##
+
+<YOUR SYNTAX ERROR MESSAGE HERE>
+
+file: FUNC ID LEFTPAR ID XOR
+##
+## Ends in an error in state: 331.
+##
+## logic_binder -> ident . COLON primitive_type [ RIGHTPAR COMMA ]
+##
+## The known suffix of the stack is as follows:
+## ident
+##
+
+<YOUR SYNTAX ERROR MESSAGE HERE>
+
+file: FUNC ID LEFTPAR ID COLON XOR
+##
+## Ends in an error in state: 332.
+##
+## logic_binder -> ident COLON . primitive_type [ RIGHTPAR COMMA ]
+##
+## The known suffix of the stack is as follows:
+## ident COLON
+##
+
+<YOUR SYNTAX ERROR MESSAGE HERE>
+
+file: FUNC ID LEFTPAR ID COLON ID XOR
+##
+## Ends in an error in state: 333.
+##
+## logic_binder -> ident COLON primitive_type . [ RIGHTPAR COMMA ]
+## primitive_type -> primitive_type . ty_ident [ RIGHTPAR ID COMMA ]
+##
+## The known suffix of the stack is as follows:
+## ident COLON primitive_type
+##
+
+<YOUR SYNTAX ERROR MESSAGE HERE>
+
+file: PRED ID EQUAL XOR
+##
+## Ends in an error in state: 335.
+##
+## separated_nonempty_list(AND,function_or_predicate_def) -> PRED raw_named_ident EQUAL . lexpr [ TYPE THEORY REWRITING PRED LOGIC GOAL FUNC EOF AXIOM ]
+## separated_nonempty_list(AND,function_or_predicate_def) -> PRED raw_named_ident EQUAL . lexpr AND separated_nonempty_list(AND,function_or_predicate_def) [ TYPE THEORY REWRITING PRED LOGIC GOAL FUNC EOF AXIOM ]
+##
+## The known suffix of the stack is as follows:
+## PRED raw_named_ident EQUAL
+##
+
+<YOUR SYNTAX ERROR MESSAGE HERE>
+
+file: PRED ID EQUAL ID RIGHTSQ
+##
+## Ends in an error in state: 336.
+##
+## lexpr -> lexpr . PLUS lexpr [ XOR TYPE TIMES THEORY SLASH RIGHTARROW REWRITING PRED POWDOT POW PLUS PERCENT OR NOTEQ MINUS LT LRARROW LOGIC LE HAT GT GOAL GE FUNC EQUAL EOF AXIOM AT AND ]
+## lexpr -> lexpr . MINUS lexpr [ XOR TYPE TIMES THEORY SLASH RIGHTARROW REWRITING PRED POWDOT POW PLUS PERCENT OR NOTEQ MINUS LT LRARROW LOGIC LE HAT GT GOAL GE FUNC EQUAL EOF AXIOM AT AND ]
+## lexpr -> lexpr . TIMES lexpr [ XOR TYPE TIMES THEORY SLASH RIGHTARROW REWRITING PRED POWDOT POW PLUS PERCENT OR NOTEQ MINUS LT LRARROW LOGIC LE HAT GT GOAL GE FUNC EQUAL EOF AXIOM AT AND ]
+## lexpr -> lexpr . SLASH lexpr [ XOR TYPE TIMES THEORY SLASH RIGHTARROW REWRITING PRED POWDOT POW PLUS PERCENT OR NOTEQ MINUS LT LRARROW LOGIC LE HAT GT GOAL GE FUNC EQUAL EOF AXIOM AT AND ]
+## lexpr -> lexpr . PERCENT lexpr [ XOR TYPE TIMES THEORY SLASH RIGHTARROW REWRITING PRED POWDOT POW PLUS PERCENT OR NOTEQ MINUS LT LRARROW LOGIC LE HAT GT GOAL GE FUNC EQUAL EOF AXIOM AT AND ]
+## lexpr -> lexpr . POW lexpr [ XOR TYPE TIMES THEORY SLASH RIGHTARROW REWRITING PRED POWDOT POW PLUS PERCENT OR NOTEQ MINUS LT LRARROW LOGIC LE HAT GT GOAL GE FUNC EQUAL EOF AXIOM AT AND ]
+## lexpr -> lexpr . POWDOT lexpr [ XOR TYPE TIMES THEORY SLASH RIGHTARROW REWRITING PRED POWDOT POW PLUS PERCENT OR NOTEQ MINUS LT LRARROW LOGIC LE HAT GT GOAL GE FUNC EQUAL EOF AXIOM AT AND ]
+## lexpr -> lexpr . AND lexpr [ XOR TYPE TIMES THEORY SLASH RIGHTARROW REWRITING PRED POWDOT POW PLUS PERCENT OR NOTEQ MINUS LT LRARROW LOGIC LE HAT GT GOAL GE FUNC EQUAL EOF AXIOM AT AND ]
+## lexpr -> lexpr . OR lexpr [ XOR TYPE TIMES THEORY SLASH RIGHTARROW REWRITING PRED POWDOT POW PLUS PERCENT OR NOTEQ MINUS LT LRARROW LOGIC LE HAT GT GOAL GE FUNC EQUAL EOF AXIOM AT AND ]
+## lexpr -> lexpr . XOR lexpr [ XOR TYPE TIMES THEORY SLASH RIGHTARROW REWRITING PRED POWDOT POW PLUS PERCENT OR NOTEQ MINUS LT LRARROW LOGIC LE HAT GT GOAL GE FUNC EQUAL EOF AXIOM AT AND ]
+## lexpr -> lexpr . LRARROW lexpr [ XOR TYPE TIMES THEORY SLASH RIGHTARROW REWRITING PRED POWDOT POW PLUS PERCENT OR NOTEQ MINUS LT LRARROW LOGIC LE HAT GT GOAL GE FUNC EQUAL EOF AXIOM AT AND ]
+## lexpr -> lexpr . RIGHTARROW lexpr [ XOR TYPE TIMES THEORY SLASH RIGHTARROW REWRITING PRED POWDOT POW PLUS PERCENT OR NOTEQ MINUS LT LRARROW LOGIC LE HAT GT GOAL GE FUNC EQUAL EOF AXIOM AT AND ]
+## lexpr -> lexpr . LT lexpr [ XOR TYPE TIMES THEORY SLASH RIGHTARROW REWRITING PRED POWDOT POW PLUS PERCENT OR NOTEQ MINUS LT LRARROW LOGIC LE HAT GT GOAL GE FUNC EQUAL EOF AXIOM AT AND ]
+## lexpr -> lexpr . LE lexpr [ XOR TYPE TIMES THEORY SLASH RIGHTARROW REWRITING PRED POWDOT POW PLUS PERCENT OR NOTEQ MINUS LT LRARROW LOGIC LE HAT GT GOAL GE FUNC EQUAL EOF AXIOM AT AND ]
+## lexpr -> lexpr . GT lexpr [ XOR TYPE TIMES THEORY SLASH RIGHTARROW REWRITING PRED POWDOT POW PLUS PERCENT OR NOTEQ MINUS LT LRARROW LOGIC LE HAT GT GOAL GE FUNC EQUAL EOF AXIOM AT AND ]
+## lexpr -> lexpr . GE lexpr [ XOR TYPE TIMES THEORY SLASH RIGHTARROW REWRITING PRED POWDOT POW PLUS PERCENT OR NOTEQ MINUS LT LRARROW LOGIC LE HAT GT GOAL GE FUNC EQUAL EOF AXIOM AT AND ]
+## lexpr -> lexpr . EQUAL lexpr [ XOR TYPE TIMES THEORY SLASH RIGHTARROW REWRITING PRED POWDOT POW PLUS PERCENT OR NOTEQ MINUS LT LRARROW LOGIC LE HAT GT GOAL GE FUNC EQUAL EOF AXIOM AT AND ]
+## lexpr -> lexpr . NOTEQ lexpr [ XOR TYPE TIMES THEORY SLASH RIGHTARROW REWRITING PRED POWDOT POW PLUS PERCENT OR NOTEQ MINUS LT LRARROW LOGIC LE HAT GT GOAL GE FUNC EQUAL EOF AXIOM AT AND ]
+## lexpr -> lexpr . HAT LEFTBR INTEGER COMMA INTEGER RIGHTBR [ XOR TYPE TIMES THEORY SLASH RIGHTARROW REWRITING PRED POWDOT POW PLUS PERCENT OR NOTEQ MINUS LT LRARROW LOGIC LE HAT GT GOAL GE FUNC EQUAL EOF AXIOM AT AND ]
+## lexpr -> lexpr . AT lexpr [ XOR TYPE TIMES THEORY SLASH RIGHTARROW REWRITING PRED POWDOT POW PLUS PERCENT OR NOTEQ MINUS LT LRARROW LOGIC LE HAT GT GOAL GE FUNC EQUAL EOF AXIOM AT AND ]
+## separated_nonempty_list(AND,function_or_predicate_def) -> PRED raw_named_ident EQUAL lexpr . [ TYPE THEORY REWRITING PRED LOGIC GOAL FUNC EOF AXIOM ]
+## separated_nonempty_list(AND,function_or_predicate_def) -> PRED raw_named_ident EQUAL lexpr . AND separated_nonempty_list(AND,function_or_predicate_def) [ TYPE THEORY REWRITING PRED LOGIC GOAL FUNC EOF AXIOM ]
 ##
 ## The known suffix of the stack is as follows:
 ## PRED raw_named_ident EQUAL lexpr
@@ -3572,9 +3746,22 @@ file: PRED ID EQUAL ID RIGHTSQ
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
+file: PRED ID EQUAL ID AND XOR
+##
+## Ends in an error in state: 337.
+##
+## lexpr -> lexpr AND . lexpr [ XOR TYPE TIMES THEORY SLASH RIGHTARROW REWRITING PRED POWDOT POW PLUS PERCENT OR NOTEQ MINUS LT LRARROW LOGIC LE HAT GT GOAL GE FUNC EQUAL EOF AXIOM AT AND ]
+## separated_nonempty_list(AND,function_or_predicate_def) -> PRED raw_named_ident EQUAL lexpr AND . separated_nonempty_list(AND,function_or_predicate_def) [ TYPE THEORY REWRITING PRED LOGIC GOAL FUNC EOF AXIOM ]
+##
+## The known suffix of the stack is as follows:
+## PRED raw_named_ident EQUAL lexpr AND
+##
+
+<YOUR SYNTAX ERROR MESSAGE HERE>
+
 file: LOGIC XOR
 ##
-## Ends in an error in state: 324.
+## Ends in an error in state: 339.
 ##
 ## decl -> LOGIC . ac_modifier separated_nonempty_list(COMMA,raw_named_ident) COLON logic_type [ TYPE THEORY REWRITING PRED LOGIC GOAL FUNC EOF AXIOM ]
 ##
@@ -3586,7 +3773,7 @@ file: LOGIC XOR
 
 file: LOGIC AC XOR
 ##
-## Ends in an error in state: 326.
+## Ends in an error in state: 341.
 ##
 ## decl -> LOGIC ac_modifier . separated_nonempty_list(COMMA,raw_named_ident) COLON logic_type [ TYPE THEORY REWRITING PRED LOGIC GOAL FUNC EOF AXIOM ]
 ##
@@ -3598,7 +3785,7 @@ file: LOGIC AC XOR
 
 file: LOGIC ID COLON XOR
 ##
-## Ends in an error in state: 328.
+## Ends in an error in state: 343.
 ##
 ## decl -> LOGIC ac_modifier separated_nonempty_list(COMMA,raw_named_ident) COLON . logic_type [ TYPE THEORY REWRITING PRED LOGIC GOAL FUNC EOF AXIOM ]
 ##
@@ -3610,7 +3797,7 @@ file: LOGIC ID COLON XOR
 
 file: LOGIC ID COLON ID XOR
 ##
-## Ends in an error in state: 332.
+## Ends in an error in state: 347.
 ##
 ## primitive_type -> primitive_type . ty_ident [ TYPE THEORY RIGHTARROW REWRITING PRED LOGIC ID GOAL FUNC EOF COMMA AXIOM ]
 ## primitive_type_or_prop -> primitive_type . [ TYPE THEORY REWRITING PRED LOGIC GOAL FUNC EOF AXIOM ]
@@ -3625,7 +3812,7 @@ file: LOGIC ID COLON ID XOR
 
 file: LOGIC ID COLON ID COMMA ID RIGHTPAR
 ##
-## Ends in an error in state: 333.
+## Ends in an error in state: 348.
 ##
 ## logic_type -> loption(separated_nonempty_list(COMMA,primitive_type)) . RIGHTARROW primitive_type_or_prop [ TYPE THEORY REWRITING PRED LOGIC GOAL FUNC EOF AXIOM ]
 ##
@@ -3638,14 +3825,14 @@ file: LOGIC ID COLON ID COMMA ID RIGHTPAR
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 37, spurious reduction of production separated_nonempty_list(COMMA,primitive_type) -> primitive_type
 ## In state 39, spurious reduction of production separated_nonempty_list(COMMA,primitive_type) -> primitive_type COMMA separated_nonempty_list(COMMA,primitive_type)
-## In state 330, spurious reduction of production loption(separated_nonempty_list(COMMA,primitive_type)) -> separated_nonempty_list(COMMA,primitive_type)
+## In state 345, spurious reduction of production loption(separated_nonempty_list(COMMA,primitive_type)) -> separated_nonempty_list(COMMA,primitive_type)
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
 file: LOGIC ID COLON RIGHTARROW XOR
 ##
-## Ends in an error in state: 334.
+## Ends in an error in state: 349.
 ##
 ## logic_type -> loption(separated_nonempty_list(COMMA,primitive_type)) RIGHTARROW . primitive_type_or_prop [ TYPE THEORY REWRITING PRED LOGIC GOAL FUNC EOF AXIOM ]
 ##
@@ -3657,7 +3844,7 @@ file: LOGIC ID COLON RIGHTARROW XOR
 
 file: LOGIC ID COLON RIGHTARROW ID XOR
 ##
-## Ends in an error in state: 336.
+## Ends in an error in state: 351.
 ##
 ## primitive_type -> primitive_type . ty_ident [ TYPE THEORY REWRITING PRED LOGIC ID GOAL FUNC EOF AXIOM ]
 ## primitive_type_or_prop -> primitive_type . [ TYPE THEORY REWRITING PRED LOGIC GOAL FUNC EOF AXIOM ]
@@ -3670,7 +3857,7 @@ file: LOGIC ID COLON RIGHTARROW ID XOR
 
 file: LOGIC ID LEFTPAR
 ##
-## Ends in an error in state: 338.
+## Ends in an error in state: 353.
 ##
 ## separated_nonempty_list(COMMA,raw_named_ident) -> raw_named_ident . [ COLON ]
 ## separated_nonempty_list(COMMA,raw_named_ident) -> raw_named_ident . COMMA separated_nonempty_list(COMMA,raw_named_ident) [ COLON ]
@@ -3689,7 +3876,7 @@ file: LOGIC ID LEFTPAR
 
 file: LOGIC ID COMMA XOR
 ##
-## Ends in an error in state: 339.
+## Ends in an error in state: 354.
 ##
 ## separated_nonempty_list(COMMA,raw_named_ident) -> raw_named_ident COMMA . separated_nonempty_list(COMMA,raw_named_ident) [ COLON ]
 ##
@@ -3701,7 +3888,7 @@ file: LOGIC ID COMMA XOR
 
 file: GOAL XOR
 ##
-## Ends in an error in state: 341.
+## Ends in an error in state: 356.
 ##
 ## decl -> GOAL . decl_ident COLON lexpr [ TYPE THEORY REWRITING PRED LOGIC GOAL FUNC EOF AXIOM ]
 ##
@@ -3713,7 +3900,7 @@ file: GOAL XOR
 
 file: GOAL ID XOR
 ##
-## Ends in an error in state: 342.
+## Ends in an error in state: 357.
 ##
 ## decl -> GOAL decl_ident . COLON lexpr [ TYPE THEORY REWRITING PRED LOGIC GOAL FUNC EOF AXIOM ]
 ##
@@ -3725,7 +3912,7 @@ file: GOAL ID XOR
 
 file: GOAL ID COLON XOR
 ##
-## Ends in an error in state: 343.
+## Ends in an error in state: 358.
 ##
 ## decl -> GOAL decl_ident COLON . lexpr [ TYPE THEORY REWRITING PRED LOGIC GOAL FUNC EOF AXIOM ]
 ##
@@ -3737,7 +3924,7 @@ file: GOAL ID COLON XOR
 
 file: GOAL ID COLON ID RIGHTSQ
 ##
-## Ends in an error in state: 344.
+## Ends in an error in state: 359.
 ##
 ## decl -> GOAL decl_ident COLON lexpr . [ TYPE THEORY REWRITING PRED LOGIC GOAL FUNC EOF AXIOM ]
 ## lexpr -> lexpr . PLUS lexpr [ XOR TYPE TIMES THEORY SLASH RIGHTARROW REWRITING PRED POWDOT POW PLUS PERCENT OR NOTEQ MINUS LT LRARROW LOGIC LE HAT GT GOAL GE FUNC EQUAL EOF AXIOM AT AND ]
@@ -3774,139 +3961,9 @@ file: GOAL ID COLON ID RIGHTSQ
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
-file: FUNC XOR
-##
-## Ends in an error in state: 345.
-##
-## function_def -> FUNC . raw_named_ident LEFTPAR loption(separated_nonempty_list(COMMA,logic_binder)) RIGHTPAR COLON primitive_type EQUAL lexpr [ TYPE THEORY REWRITING PRED LOGIC GOAL FUNC EOF AXIOM AND ]
-##
-## The known suffix of the stack is as follows:
-## FUNC
-##
-
-<YOUR SYNTAX ERROR MESSAGE HERE>
-
-file: FUNC ID EQUAL
-##
-## Ends in an error in state: 346.
-##
-## function_def -> FUNC raw_named_ident . LEFTPAR loption(separated_nonempty_list(COMMA,logic_binder)) RIGHTPAR COLON primitive_type EQUAL lexpr [ TYPE THEORY REWRITING PRED LOGIC GOAL FUNC EOF AXIOM AND ]
-##
-## The known suffix of the stack is as follows:
-## FUNC raw_named_ident
-##
-## WARNING: This example involves spurious reductions.
-## This implies that, although the LR(1) items shown above provide an
-## accurate view of the past (what has been recognized so far), they
-## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 109, spurious reduction of production raw_named_ident -> ID
-##
-
-<YOUR SYNTAX ERROR MESSAGE HERE>
-
-file: FUNC ID LEFTPAR XOR
-##
-## Ends in an error in state: 347.
-##
-## function_def -> FUNC raw_named_ident LEFTPAR . loption(separated_nonempty_list(COMMA,logic_binder)) RIGHTPAR COLON primitive_type EQUAL lexpr [ TYPE THEORY REWRITING PRED LOGIC GOAL FUNC EOF AXIOM AND ]
-##
-## The known suffix of the stack is as follows:
-## FUNC raw_named_ident LEFTPAR
-##
-
-<YOUR SYNTAX ERROR MESSAGE HERE>
-
-file: FUNC ID LEFTPAR RIGHTPAR XOR
-##
-## Ends in an error in state: 349.
-##
-## function_def -> FUNC raw_named_ident LEFTPAR loption(separated_nonempty_list(COMMA,logic_binder)) RIGHTPAR . COLON primitive_type EQUAL lexpr [ TYPE THEORY REWRITING PRED LOGIC GOAL FUNC EOF AXIOM AND ]
-##
-## The known suffix of the stack is as follows:
-## FUNC raw_named_ident LEFTPAR loption(separated_nonempty_list(COMMA,logic_binder)) RIGHTPAR
-##
-
-<YOUR SYNTAX ERROR MESSAGE HERE>
-
-file: FUNC ID LEFTPAR RIGHTPAR COLON XOR
-##
-## Ends in an error in state: 350.
-##
-## function_def -> FUNC raw_named_ident LEFTPAR loption(separated_nonempty_list(COMMA,logic_binder)) RIGHTPAR COLON . primitive_type EQUAL lexpr [ TYPE THEORY REWRITING PRED LOGIC GOAL FUNC EOF AXIOM AND ]
-##
-## The known suffix of the stack is as follows:
-## FUNC raw_named_ident LEFTPAR loption(separated_nonempty_list(COMMA,logic_binder)) RIGHTPAR COLON
-##
-
-<YOUR SYNTAX ERROR MESSAGE HERE>
-
-file: FUNC ID LEFTPAR RIGHTPAR COLON ID XOR
-##
-## Ends in an error in state: 351.
-##
-## function_def -> FUNC raw_named_ident LEFTPAR loption(separated_nonempty_list(COMMA,logic_binder)) RIGHTPAR COLON primitive_type . EQUAL lexpr [ TYPE THEORY REWRITING PRED LOGIC GOAL FUNC EOF AXIOM AND ]
-## primitive_type -> primitive_type . ty_ident [ ID EQUAL ]
-##
-## The known suffix of the stack is as follows:
-## FUNC raw_named_ident LEFTPAR loption(separated_nonempty_list(COMMA,logic_binder)) RIGHTPAR COLON primitive_type
-##
-
-<YOUR SYNTAX ERROR MESSAGE HERE>
-
-file: FUNC ID LEFTPAR RIGHTPAR COLON ID EQUAL XOR
-##
-## Ends in an error in state: 352.
-##
-## function_def -> FUNC raw_named_ident LEFTPAR loption(separated_nonempty_list(COMMA,logic_binder)) RIGHTPAR COLON primitive_type EQUAL . lexpr [ TYPE THEORY REWRITING PRED LOGIC GOAL FUNC EOF AXIOM AND ]
-##
-## The known suffix of the stack is as follows:
-## FUNC raw_named_ident LEFTPAR loption(separated_nonempty_list(COMMA,logic_binder)) RIGHTPAR COLON primitive_type EQUAL
-##
-
-<YOUR SYNTAX ERROR MESSAGE HERE>
-
-file: FUNC ID LEFTPAR RIGHTPAR COLON ID EQUAL ID RIGHTSQ
-##
-## Ends in an error in state: 353.
-##
-## function_def -> FUNC raw_named_ident LEFTPAR loption(separated_nonempty_list(COMMA,logic_binder)) RIGHTPAR COLON primitive_type EQUAL lexpr . [ TYPE THEORY REWRITING PRED LOGIC GOAL FUNC EOF AXIOM AND ]
-## lexpr -> lexpr . PLUS lexpr [ XOR TYPE TIMES THEORY SLASH RIGHTARROW REWRITING PRED POWDOT POW PLUS PERCENT OR NOTEQ MINUS LT LRARROW LOGIC LE HAT GT GOAL GE FUNC EQUAL EOF AXIOM AT AND ]
-## lexpr -> lexpr . MINUS lexpr [ XOR TYPE TIMES THEORY SLASH RIGHTARROW REWRITING PRED POWDOT POW PLUS PERCENT OR NOTEQ MINUS LT LRARROW LOGIC LE HAT GT GOAL GE FUNC EQUAL EOF AXIOM AT AND ]
-## lexpr -> lexpr . TIMES lexpr [ XOR TYPE TIMES THEORY SLASH RIGHTARROW REWRITING PRED POWDOT POW PLUS PERCENT OR NOTEQ MINUS LT LRARROW LOGIC LE HAT GT GOAL GE FUNC EQUAL EOF AXIOM AT AND ]
-## lexpr -> lexpr . SLASH lexpr [ XOR TYPE TIMES THEORY SLASH RIGHTARROW REWRITING PRED POWDOT POW PLUS PERCENT OR NOTEQ MINUS LT LRARROW LOGIC LE HAT GT GOAL GE FUNC EQUAL EOF AXIOM AT AND ]
-## lexpr -> lexpr . PERCENT lexpr [ XOR TYPE TIMES THEORY SLASH RIGHTARROW REWRITING PRED POWDOT POW PLUS PERCENT OR NOTEQ MINUS LT LRARROW LOGIC LE HAT GT GOAL GE FUNC EQUAL EOF AXIOM AT AND ]
-## lexpr -> lexpr . POW lexpr [ XOR TYPE TIMES THEORY SLASH RIGHTARROW REWRITING PRED POWDOT POW PLUS PERCENT OR NOTEQ MINUS LT LRARROW LOGIC LE HAT GT GOAL GE FUNC EQUAL EOF AXIOM AT AND ]
-## lexpr -> lexpr . POWDOT lexpr [ XOR TYPE TIMES THEORY SLASH RIGHTARROW REWRITING PRED POWDOT POW PLUS PERCENT OR NOTEQ MINUS LT LRARROW LOGIC LE HAT GT GOAL GE FUNC EQUAL EOF AXIOM AT AND ]
-## lexpr -> lexpr . AND lexpr [ XOR TYPE TIMES THEORY SLASH RIGHTARROW REWRITING PRED POWDOT POW PLUS PERCENT OR NOTEQ MINUS LT LRARROW LOGIC LE HAT GT GOAL GE FUNC EQUAL EOF AXIOM AT AND ]
-## lexpr -> lexpr . OR lexpr [ XOR TYPE TIMES THEORY SLASH RIGHTARROW REWRITING PRED POWDOT POW PLUS PERCENT OR NOTEQ MINUS LT LRARROW LOGIC LE HAT GT GOAL GE FUNC EQUAL EOF AXIOM AT AND ]
-## lexpr -> lexpr . XOR lexpr [ XOR TYPE TIMES THEORY SLASH RIGHTARROW REWRITING PRED POWDOT POW PLUS PERCENT OR NOTEQ MINUS LT LRARROW LOGIC LE HAT GT GOAL GE FUNC EQUAL EOF AXIOM AT AND ]
-## lexpr -> lexpr . LRARROW lexpr [ XOR TYPE TIMES THEORY SLASH RIGHTARROW REWRITING PRED POWDOT POW PLUS PERCENT OR NOTEQ MINUS LT LRARROW LOGIC LE HAT GT GOAL GE FUNC EQUAL EOF AXIOM AT AND ]
-## lexpr -> lexpr . RIGHTARROW lexpr [ XOR TYPE TIMES THEORY SLASH RIGHTARROW REWRITING PRED POWDOT POW PLUS PERCENT OR NOTEQ MINUS LT LRARROW LOGIC LE HAT GT GOAL GE FUNC EQUAL EOF AXIOM AT AND ]
-## lexpr -> lexpr . LT lexpr [ XOR TYPE TIMES THEORY SLASH RIGHTARROW REWRITING PRED POWDOT POW PLUS PERCENT OR NOTEQ MINUS LT LRARROW LOGIC LE HAT GT GOAL GE FUNC EQUAL EOF AXIOM AT AND ]
-## lexpr -> lexpr . LE lexpr [ XOR TYPE TIMES THEORY SLASH RIGHTARROW REWRITING PRED POWDOT POW PLUS PERCENT OR NOTEQ MINUS LT LRARROW LOGIC LE HAT GT GOAL GE FUNC EQUAL EOF AXIOM AT AND ]
-## lexpr -> lexpr . GT lexpr [ XOR TYPE TIMES THEORY SLASH RIGHTARROW REWRITING PRED POWDOT POW PLUS PERCENT OR NOTEQ MINUS LT LRARROW LOGIC LE HAT GT GOAL GE FUNC EQUAL EOF AXIOM AT AND ]
-## lexpr -> lexpr . GE lexpr [ XOR TYPE TIMES THEORY SLASH RIGHTARROW REWRITING PRED POWDOT POW PLUS PERCENT OR NOTEQ MINUS LT LRARROW LOGIC LE HAT GT GOAL GE FUNC EQUAL EOF AXIOM AT AND ]
-## lexpr -> lexpr . EQUAL lexpr [ XOR TYPE TIMES THEORY SLASH RIGHTARROW REWRITING PRED POWDOT POW PLUS PERCENT OR NOTEQ MINUS LT LRARROW LOGIC LE HAT GT GOAL GE FUNC EQUAL EOF AXIOM AT AND ]
-## lexpr -> lexpr . NOTEQ lexpr [ XOR TYPE TIMES THEORY SLASH RIGHTARROW REWRITING PRED POWDOT POW PLUS PERCENT OR NOTEQ MINUS LT LRARROW LOGIC LE HAT GT GOAL GE FUNC EQUAL EOF AXIOM AT AND ]
-## lexpr -> lexpr . HAT LEFTBR INTEGER COMMA INTEGER RIGHTBR [ XOR TYPE TIMES THEORY SLASH RIGHTARROW REWRITING PRED POWDOT POW PLUS PERCENT OR NOTEQ MINUS LT LRARROW LOGIC LE HAT GT GOAL GE FUNC EQUAL EOF AXIOM AT AND ]
-## lexpr -> lexpr . AT lexpr [ XOR TYPE TIMES THEORY SLASH RIGHTARROW REWRITING PRED POWDOT POW PLUS PERCENT OR NOTEQ MINUS LT LRARROW LOGIC LE HAT GT GOAL GE FUNC EQUAL EOF AXIOM AT AND ]
-##
-## The known suffix of the stack is as follows:
-## FUNC raw_named_ident LEFTPAR loption(separated_nonempty_list(COMMA,logic_binder)) RIGHTPAR COLON primitive_type EQUAL lexpr
-##
-## WARNING: This example involves spurious reductions.
-## This implies that, although the LR(1) items shown above provide an
-## accurate view of the past (what has been recognized so far), they
-## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 144, spurious reduction of production simple_expr -> ident
-## In state 124, spurious reduction of production lexpr -> simple_expr
-##
-
-<YOUR SYNTAX ERROR MESSAGE HERE>
-
 file: AXIOM XOR
 ##
-## Ends in an error in state: 354.
+## Ends in an error in state: 360.
 ##
 ## decl -> AXIOM . decl_ident COLON lexpr [ TYPE THEORY REWRITING PRED LOGIC GOAL FUNC EOF AXIOM ]
 ##
@@ -3918,7 +3975,7 @@ file: AXIOM XOR
 
 file: AXIOM ID XOR
 ##
-## Ends in an error in state: 355.
+## Ends in an error in state: 361.
 ##
 ## decl -> AXIOM decl_ident . COLON lexpr [ TYPE THEORY REWRITING PRED LOGIC GOAL FUNC EOF AXIOM ]
 ##
@@ -3930,7 +3987,7 @@ file: AXIOM ID XOR
 
 file: AXIOM ID COLON XOR
 ##
-## Ends in an error in state: 356.
+## Ends in an error in state: 362.
 ##
 ## decl -> AXIOM decl_ident COLON . lexpr [ TYPE THEORY REWRITING PRED LOGIC GOAL FUNC EOF AXIOM ]
 ##
@@ -3942,7 +3999,7 @@ file: AXIOM ID COLON XOR
 
 file: AXIOM ID COLON ID RIGHTSQ
 ##
-## Ends in an error in state: 357.
+## Ends in an error in state: 363.
 ##
 ## decl -> AXIOM decl_ident COLON lexpr . [ TYPE THEORY REWRITING PRED LOGIC GOAL FUNC EOF AXIOM ]
 ## lexpr -> lexpr . PLUS lexpr [ XOR TYPE TIMES THEORY SLASH RIGHTARROW REWRITING PRED POWDOT POW PLUS PERCENT OR NOTEQ MINUS LT LRARROW LOGIC LE HAT GT GOAL GE FUNC EQUAL EOF AXIOM AT AND ]
@@ -3979,21 +4036,9 @@ file: AXIOM ID COLON ID RIGHTSQ
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
-file: PRED ID EQUAL ID AND XOR
-##
-## Ends in an error in state: 363.
-##
-## separated_nonempty_list(AND,function_or_predicate_def) -> function_or_predicate_def AND . separated_nonempty_list(AND,function_or_predicate_def) [ TYPE THEORY REWRITING PRED LOGIC GOAL FUNC EOF AXIOM ]
-##
-## The known suffix of the stack is as follows:
-## function_or_predicate_def AND
-##
-
-<YOUR SYNTAX ERROR MESSAGE HERE>
-
 file: LOGIC ID COLON PROP XOR
 ##
-## Ends in an error in state: 367.
+## Ends in an error in state: 368.
 ##
 ## list(decl) -> decl . list(decl) [ EOF ]
 ##
@@ -4005,7 +4050,7 @@ file: LOGIC ID COLON PROP XOR
 
 input: XOR
 ##
-## Ends in an error in state: 369.
+## Ends in an error in state: 370.
 ##
 ## input' -> . input [ # ]
 ##

--- a/tests/parsing/ae/pass/dune
+++ b/tests/parsing/ae/pass/dune
@@ -18,6 +18,23 @@
   (action (diff test-mut-fun_def_1.expected test-mut-fun_def_1.full)))
 
 
+; Test for test-mut-pred_dec_2.ae
+; Full mode test
+
+(rule
+   (target  test-mut-pred_dec_2.full)
+   (deps    (:input test-mut-pred_dec_2.ae))
+   (package dolmen_bin)
+   (action (chdir %{workspace_root}
+            (with-outputs-to %{target}
+             (with-accepted-exit-codes (or 0 (not 0))
+              (run dolmen --mode=full --color=never %{input} %{read-lines:flags.dune}))))))
+(rule
+  (alias runtest)
+  (package dolmen_bin)
+  (action (diff test-mut-pred_dec_2.expected test-mut-pred_dec_2.full)))
+
+
 ; Test for test-mut-pred_def_1.ae
 ; Full mode test
 

--- a/tests/parsing/ae/pass/test-mut-pred_dec_2.ae
+++ b/tests/parsing/ae/pass/test-mut-pred_dec_2.ae
@@ -1,0 +1,3 @@
+predicate A = true and true and false and true
+
+goal g: A


### PR DESCRIPTION
In #129 support was added for mutually recursive function and predicate definitions using the "and" keyword.

However, the keyword "and" can also be used to denote the boolean conjunection, but now the conflicts are resolved in such a way that:

```
predicate X = true and true
```

is now a syntax error (upon seeing the [and] token, [predicate X = true] gets reduced into a [predicate_def], and a recursive [function] or [predicate] definition is expected).

This patch fixes the issue by marking the appropriate rules (predicate_def, function_def) as inline, propagating enough context to the conflict that it can be resolved appropriately.

Note that we are still not able to parse horrors such as:

```
predicate X = true and true and predicate Y = true
```

but that is OK because those were never supported by Alt-Ergo.

(as an aside, I don't think it's even possible by using a %right associative token for AND in Menhir)