### PR TITLE
Fix reason for reserved builtins

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -33,6 +33,7 @@ next
   `arith`, `arrays`, etc..) (PR#142)
 - Add printing function for logics (PR#142)
 - Attach type definitions to type-defs (PR#157)
+- Add a proper reason for reserved builtins (PR#155)
 
 ### Loop
 

--- a/src/typecheck/arith.ml
+++ b/src/typecheck/arith.ml
@@ -800,8 +800,13 @@ module Smtlib2 = struct
             | ">" ->
               Type.builtin_term (Base.term_app_chain (module Type) env s T.gt
                     ~check:(check env (F.comp config (parse ~config) version env)))
-            | "div0" -> `Reserved (`Term_cst (fun _ _ _ -> T.div'))
-            | "mod0" -> `Reserved (`Term_cst (fun _ _ _ -> T.rem'))
+
+            | "div0" -> `Reserved (
+                "completing interpretation of division by zero in models",
+                `Term_cst (fun _ _ _ -> T.div'))
+            | "mod0" -> `Reserved (
+                "completing interpretation of modulo by zero in models",
+                `Term_cst (fun _ _ _ -> T.rem'))
 
             | _ -> `Not_found
           end
@@ -886,7 +891,9 @@ module Smtlib2 = struct
               Type.builtin_term (Base.term_app_chain (module Type) env s T.gt
                        ~check:(check env (F.comp config (parse ~config) version env)))
 
-            | "/0" -> `Reserved (`Term_cst (fun _ _ _ -> T.div'))
+            | "/0" -> `Reserved (
+                "completing interpretation of division by zero in models",
+                `Term_cst (fun _ _ _ -> T.div'))
 
             | _ -> `Not_found
           end
@@ -1021,9 +1028,18 @@ module Smtlib2 = struct
               Type.builtin_term (Base.term_app1 (module Type) env s T.Real.is_int)
 
 
-            | "/0" -> `Reserved (`Term_cst (fun _ _ _ -> T.Real.div'))
-            | "div0" -> `Reserved (`Term_cst (fun _ _ _ -> T.Int.div'))
-            | "mod0" -> `Reserved (`Term_cst (fun _ _ _ -> T.Int.rem'))
+            | "/0" ->
+              `Reserved (
+                "completing interpretation of division by zero in models",
+                `Term_cst (fun _ _ _ -> T.Real.div'))
+            | "div0" ->
+              `Reserved (
+                "completing interpretation of division by zero in models",
+                `Term_cst (fun _ _ _ -> T.Int.div'))
+            | "mod0" ->
+              `Reserved (
+                "completing interpretation of modulo by zero in models",
+                `Term_cst (fun _ _ _ -> T.Int.rem'))
 
             | _ -> `Not_found
           end

--- a/src/typecheck/core.ml
+++ b/src/typecheck/core.ml
@@ -614,12 +614,18 @@ module Smtlib2 = struct
           match name.[0] with
           | '.' ->
             begin match version with
-              | `Script _ -> `Reserved `Solver
-              | `Response _ -> `Not_found (* TODO: check what these are used for *)
+              | `Script _ ->
+                `Reserved (
+                  "solver-generated function symbols other than abstract values",
+                  `Solver)
+              (* this is effectively a namespace reserved for solver-generated symbols
+                 in their output. In such case, we expect these symbols to be explicitly
+                 bound/defined somewher, so we need not do anything specific. *)
+              | `Response _ -> `Not_found
             end
           | '@' ->
             begin match version with
-              | `Script _ -> `Reserved `Solver
+              | `Script _ -> `Reserved ("abstract values in models", `Solver)
               | `Response _ ->
                 (* the var infer does not matter *)
                 let var_infer = Type.var_infer env in
@@ -637,7 +643,7 @@ module Smtlib2 = struct
                   infer_type_csts = false;
                   infer_term_csts = Wildcard Any_in_scope;
                 } in
-                `Infer (var_infer, sym_infer)
+                `Infer ("abstract values (i.e. constants)", var_infer, sym_infer)
             end
           | _ -> `Not_found
         end

--- a/src/typecheck/float.ml
+++ b/src/typecheck/float.ml
@@ -196,7 +196,10 @@ module Smtlib2 = struct
             Type.builtin_term (Base.term_app1 (module Type) env s F.to_real)
           | "fp.to_ubv" ->
             begin match version with
-              | `Response _ -> `Reserved (`Term_cst (meta_to_bv F.to_ubv'))
+              | `Response _ ->
+                `Reserved (
+                  "completing interpretation of fp.to_bv in models",
+                  `Term_cst (meta_to_bv F.to_ubv'))
               | `Script _ ->
                 Format.eprintf "foo ?!@.";
                 (* the regular case is handled later, because fp.to_ubv is
@@ -205,7 +208,10 @@ module Smtlib2 = struct
             end
           | "fp.to_sbv" ->
             begin match version with
-              | `Response _ -> `Reserved (`Term_cst (meta_to_bv F.to_sbv'))
+              | `Response _ ->
+                `Reserved (
+                  "completing interpretation of fp.to_sbv in models",
+                  `Term_cst (meta_to_bv F.to_sbv'))
               | `Script _ ->
                 (* the regular case is handled later, because fp.to_sbv is
                    an indexed identifier. *)

--- a/src/typecheck/intf.ml
+++ b/src/typecheck/intf.ml
@@ -163,11 +163,11 @@ module type Formulas = sig
     | `Ty    of (ty, builtin_meta_ty) builtin_common_res
     | `Term  of (term, builtin_meta_term) builtin_common_res
     | `Tags  of (tag list, builtin_meta_tags) builtin_common_res
-    | `Reserved of [
+    | `Reserved of string * [
         | `Solver
         | `Term_cst of (ty_var list -> term_var list -> ty -> term_cst)
       ]
-    | `Infer of var_infer * sym_infer
+    | `Infer of string * var_infer * sym_infer
   ]
   (** The result of parsing a symbol by the theory *)
 
@@ -175,7 +175,8 @@ module type Formulas = sig
   (** Not bound bindings *)
 
   type reason =
-    | Builtin | Reserved
+    | Builtin
+    | Reserved of string
     | Bound of Dolmen.Std.Loc.file * Dolmen.Std.Term.t
     | Inferred of Dolmen.Std.Loc.file * Dolmen.Std.Term.t
     | Defined of Dolmen.Std.Loc.file * Dolmen.Std.Statement.def
@@ -187,10 +188,7 @@ module type Formulas = sig
 
   type binding = [
     | `Not_found
-    | `Reserved of [
-        | `Solver
-        | `Term
-      ]
+    | `Reserved of string
     | `Builtin of [
         | `Ttype
         | `Ty

--- a/src/typecheck/thf.ml
+++ b/src/typecheck/thf.ml
@@ -203,11 +203,11 @@ module Make
   ]
 
   type builtin_infer = [
-    | `Infer of var_infer * sym_infer
+    | `Infer of string * var_infer * sym_infer
   ]
 
   type builtin_reserved = [
-    | `Reserved of [
+    | `Reserved of string * [
         | `Solver
         | `Term_cst of (Ty.Var.t list -> T.Var.t list -> Ty.t -> T.Const.t)
       ]
@@ -222,7 +222,7 @@ module Make
 
   type reason =
     | Builtin
-    | Reserved
+    | Reserved of string
     | Bound of Loc.file * Ast.t
     | Inferred of Loc.file * Ast.t
     | Defined of Loc.file * Stmt.def
@@ -234,10 +234,7 @@ module Make
 
   type binding = [
     | `Not_found
-    | `Reserved of [
-        | `Solver
-        | `Term
-      ]
+    | `Reserved of string
     | `Builtin of [
         | `Ttype
         | `Ty
@@ -550,7 +547,7 @@ module Make
     try
       let r =
         match v with
-        | `Builtin `Reserved _ -> Reserved
+        | `Builtin `Reserved (reason, _) -> Reserved reason
         | `Builtin _ -> Builtin
         | `Ty_var v -> E.find v env.type_locs
         | `Term_var v -> F.find v env.term_locs
@@ -567,16 +564,13 @@ module Make
   let with_reason reason bound : binding =
     match (bound : [ bound | not_found ]) with
     | `Not_found -> `Not_found
-    | `Builtin `Infer _ ->
-      (* infer-builtins should not last long: they should be instantly
-         replaced by the corresponding inferred constant. *)
-      assert false
+    | `Builtin `Infer (reason, _, _) -> `Reserved reason
     | `Builtin `Ttype _ -> `Builtin `Ttype
     | `Builtin `Ty _ -> `Builtin `Ty
     | `Builtin `Term _ -> `Builtin `Term
     | `Builtin `Tags _ -> `Builtin `Tag
-    | `Builtin `Reserved `Solver -> `Reserved `Solver
-    | `Builtin `Reserved `Term_cst _ -> `Reserved `Term
+    | `Builtin `Reserved (reason, `Solver) -> `Reserved reason
+    | `Builtin `Reserved (reason, `Term_cst _) -> `Reserved reason
     | `Ty_var v -> `Variable (`Ty (v, reason))
     | `Term_var v -> `Variable (`Term (v, reason))
     | `Letin (_, _, v, _) -> `Variable (`Term (v, reason))
@@ -590,7 +584,7 @@ module Make
     match (binding : binding) with
     | `Not_found -> assert false
     | `Builtin _ -> Some Builtin
-    | `Reserved _ -> Some Reserved
+    | `Reserved reason -> Some (Reserved reason)
     | `Variable `Ty (_, reason)
     | `Variable `Term (_, reason)
     | `Constant `Ty (_, reason)
@@ -1122,7 +1116,7 @@ module Make
     | Bound (_, t) | Inferred (_, t) ->
       _warn env (Ast t) (Unused_type_variable (kind, v))
     (* variables should not be declare-able nor builtin *)
-    | Builtin | Reserved | Declared _ | Defined _
+    | Builtin | Reserved _ | Declared _ | Defined _
     | Implicit_in_def _ | Implicit_in_decl _ | Implicit_in_term _ ->
       assert false
 
@@ -1136,7 +1130,7 @@ module Make
       _warn env (Ast t) (Unused_term_variable (kind, v))
     (* variables should not be declare-able nor builtin,
        and we do not use any term wildcards. *)
-    | Builtin | Reserved | Declared _ | Defined _
+    | Builtin | Reserved _ | Declared _ | Defined _
     | Implicit_in_def _ | Implicit_in_decl _ | Implicit_in_term _ ->
       assert false
 
@@ -1864,9 +1858,9 @@ module Make
   and builtin_apply_id env b ast s s_ast args : res =
     match (b : builtin_res) with
     | #builtin_common as b -> builtin_apply_common env b ast args
-    | `Infer (var_infer, sym_infer) ->
+    | `Infer (_reason, var_infer, sym_infer) ->
       infer_sym_aux env var_infer sym_infer ast s args s_ast
-    | `Reserved (`Solver | `Term_cst _ ) ->
+    | `Reserved (_reason, (`Solver | `Term_cst _ )) ->
       (* reserved builtins are there to provide shadow warnings
          and provide symbols for model definitions, but they don't
          have a semantic outside of that. *)
@@ -1951,7 +1945,7 @@ module Make
   and builtin_apply_builtin env ast b b_res args : res =
     match (b_res : builtin_res) with
     | #builtin_common as b -> builtin_apply_common env b ast args
-    | `Reserved (`Solver | `Term_cst _) -> _unknown_builtin env ast b
+    | `Reserved (_reason, (`Solver | `Term_cst _)) -> _unknown_builtin env ast b
     | `Infer _ ->
       (* TODO: proper erorr.
          We do not have a map from builtins symbols to typed expressions. *)
@@ -2455,7 +2449,7 @@ module Make
           assert false (* missing reason for destructor *)
       end
     | `Term_def ret_ty, `Builtin `Term (`Partial mk_cst, _)
-    | `Term_def ret_ty, `Builtin `Reserved `Term_cst mk_cst ->
+    | `Term_def ret_ty, `Builtin `Reserved (_, `Term_cst mk_cst) ->
       let cst = mk_cst vars params ret_ty in
       lookup_id_for_def_term env d vars params ret_ty cst Builtin
     | `Term_def ret_ty, ((`Term_cst cst) as c) ->

--- a/tests/model/funs/dune
+++ b/tests/model/funs/dune
@@ -129,4 +129,36 @@
   (action (diff out_of_order.expected out_of_order.full)))
 
 
+; Test for reserved.smt2
+; Incremental test
+
+(rule
+   (target  reserved.incremental)
+   (deps    (:response reserved.rsmt2) (:input reserved.smt2))
+   (package dolmen_bin)
+   (action (chdir %{workspace_root}
+            (with-outputs-to %{target}
+             (with-accepted-exit-codes (or 0 (not 0))
+              (run dolmen --check-model=true -r %{response} --mode=incremental --color=never %{input} %{read-lines:flags.dune}))))))
+(rule
+  (alias runtest)
+  (package dolmen_bin)
+  (action (diff reserved.expected reserved.incremental)))
+
+; Full mode test
+
+(rule
+   (target  reserved.full)
+   (deps    (:response reserved.rsmt2) (:input reserved.smt2))
+   (package dolmen_bin)
+   (action (chdir %{workspace_root}
+            (with-outputs-to %{target}
+             (with-accepted-exit-codes (or 0 (not 0))
+              (run dolmen --check-model=true -r %{response} --mode=full --color=never %{input} %{read-lines:flags.dune}))))))
+(rule
+  (alias runtest)
+  (package dolmen_bin)
+  (action (diff reserved.expected reserved.full)))
+
+
 ; Auto-generated part end

--- a/tests/model/funs/reserved.expected
+++ b/tests/model/funs/reserved.expected
@@ -1,0 +1,1 @@
+run 'make promote' to update this file

--- a/tests/model/funs/reserved.expected
+++ b/tests/model/funs/reserved.expected
@@ -1,1 +1,8 @@
-run 'make promote' to update this file
+File "tests/model/funs/reserved.rsmt2", line 9, character 15-26:
+9 | (define-fun f ((@_arg_1 t)) t (as @a2 t))
+                   ^^^^^^^^^^^
+Warning Shadowing: `@_arg_1` is reserved for abstract values (i.e. constants)
+File "tests/model/funs/reserved.rsmt2", line 9, character 15-26:
+9 | (define-fun f ((@_arg_1 t)) t (as @a2 t))
+                   ^^^^^^^^^^^
+Warning The following function parameter is unused: `@_arg_1`

--- a/tests/model/funs/reserved.rsmt2
+++ b/tests/model/funs/reserved.rsmt2
@@ -1,0 +1,10 @@
+sat
+(
+; cardinality of t is 3
+; rep: (as @a0 t)
+; rep: (as @a1 t)
+; rep: (as @a2 t)
+(define-fun a () t (as @a0 t))
+(define-fun b () t (as @a1 t))
+(define-fun f ((@_arg_1 t)) t (as @a2 t))
+)

--- a/tests/model/funs/reserved.smt2
+++ b/tests/model/funs/reserved.smt2
@@ -1,0 +1,11 @@
+(set-logic QF_UF)
+
+(declare-sort t 0)
+
+(declare-fun a () t)
+(declare-fun b () t)
+(declare-fun f (t) t)
+
+(assert (not (= a (f b))))
+
+(check-sat)

--- a/tests/typing/warnings/shadow/reserved_const.expected
+++ b/tests/typing/warnings/shadow/reserved_const.expected
@@ -1,4 +1,5 @@
 File "tests/typing/warnings/shadow/reserved_const.smt2", line 2, character 0-25:
 2 | (declare-fun div0 () Int)
     ^^^^^^^^^^^^^^^^^^^^^^^^^
-Warning Shadowing: `div0` is reserved for model definitions
+Warning Shadowing: `div0` is reserved for completing interpretation of
+        division by zero in models


### PR DESCRIPTION
Previously, reserved builtins were thought to be very transient and therefore, it seemed like getting a binding reason for one was likely to be an error (e.g. a builtin that should have existed for a very brief period of time, but somehow leaked out). However, that's not the case: most notably when a model tries and bind a reserved identifier (and not at its expted place), for instance binding a variable with a name reserved for abstract values (i.e. starting with an `@` in smtlib2), then we need the reason for the reserved name.