### PR TITLE
Add convenience State.update and State.update_opt

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -36,6 +36,7 @@ next
   exit/return code for a `Code.t` (PR#134)
 - Add the `Flow` module for flow checking (PR#135)
 - Add the `check` function in `typer.ml`/`typer_intf.ml`
+- Add `update` and `update_opt` in `State`
 
 ### Model
 

--- a/src/loop/state.ml
+++ b/src/loop/state.ml
@@ -105,13 +105,16 @@ module type S = sig
   (** [update key f s] updates the value associated with the key [key]
       according to the result of [f].
 
-      @raises Key_not_found if the key is not bound. *)
+      @raises Key_not_found if the key is not bound.
+      @since 0.9 *)
 
   val update_opt : 'a key -> ('a option -> 'a option) -> t -> t
   (** [update_opt key f s] updates the value associated with the key [key]
       according to the result of [f]. The argument passed to [f] is [Some v]
       if the key is currently associated with value [v], and [None] if the key
-      is not bound. *)
+      is not bound.
+
+      @since 0.9 *)
 
   val warn :
     ?file:_ file ->

--- a/src/standard/hmap.mli
+++ b/src/standard/hmap.mli
@@ -31,6 +31,11 @@ module type S = sig
   val add : inj:'a injection -> key -> 'a -> t -> t
   (** Bind the key to the value, using [inj]. *)
 
+  val update : inj:'a injection -> key -> ('a option -> 'a option) -> t -> t
+  (** [update ~inj k f m] updates the value associated with [k] in [m] according
+      to [f (get ~inj k m)]. If the result is [None], the binding associated
+      with [k] is removed. *)
+
   val find : inj:'a injection -> key -> t -> 'a
   (** Find the value for the given key, which must be of the right type.
       @raise Not_found if either the key is not found, or if its value

--- a/src/standard/hmap.mli
+++ b/src/standard/hmap.mli
@@ -34,7 +34,9 @@ module type S = sig
   val update : inj:'a injection -> key -> ('a option -> 'a option) -> t -> t
   (** [update ~inj k f m] updates the value associated with [k] in [m] according
       to [f (get ~inj k m)]. If the result is [None], the binding associated
-      with [k] is removed. *)
+      with [k] is removed.
+
+      @since 0.9 *)
 
   val find : inj:'a injection -> key -> t -> 'a
   (** Find the value for the given key, which must be of the right type.


### PR DESCRIPTION
These wrappers around `Stdlib.Map.S.update` allow updating the state in a more functional way than using a sequence of `get` and `set` calls.