### PR TITLE
Add printing of type definitions in debug output

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -32,7 +32,7 @@ next
 - Rename theory-specific configuration to `config` (instead of
   `arith`, `arrays`, etc..) (PR#142)
 - Add printing function for logics (PR#142)
-
+- Attach type definitions to type-defs (PR#157)
 
 ### Loop
 
@@ -41,6 +41,7 @@ next
 - Add the `Flow` module for flow checking (PR#135)
 - Add the `check` function in `typer.ml`/`typer_intf.ml`
 - Add `update` and `update_opt` in `State` (PR#156)
+- Print type definitions in the printer of typed statements (PR#157)
 
 ### Model
 

--- a/src/interface/term.ml
+++ b/src/interface/term.ml
@@ -373,7 +373,9 @@ module type Tff = sig
   type ty
   type ty_var
   type ty_const
-  (** The representation of term types, type variables, and type constants. *)
+  type ty_def
+  (** The representation of term types, type variables, and type constants,
+      and lastly type definitions. *)
 
   type 'a tag
   (** The type of tags used to annotate arbitrary terms. *)
@@ -475,7 +477,7 @@ module type Tff = sig
   val define_adt :
     ty_const -> ty_var list ->
     (path * (ty * path option) list) list ->
-    (Cstr.t * (ty * Const.t option) list) list
+    ty_def * (Cstr.t * (ty * Const.t option) list) list
   (** [define_aft t vars cstrs] defines the type constant [t], parametrised over
       the type variables [ty_vars] as defining an algebraic datatypes with constructors
       [cstrs]. [cstrs] is a list where each elements of the form [(name, l)] defines
@@ -502,7 +504,7 @@ module type Tff = sig
   *)
 
   val define_record :
-    ty_const -> ty_var list -> (path * ty) list -> Field.t list
+    ty_const -> ty_var list -> (path * ty) list -> ty_def * Field.t list
   (** Define a (previously abstract) type to be a record type, with the given fields. *)
 
   exception Wrong_type of t * ty

--- a/src/interface/ty.ml
+++ b/src/interface/ty.ml
@@ -15,6 +15,9 @@ module type Tff = sig
   type t
   (** The type of types. *)
 
+  type def
+  (** The type of type definitions *)
+
   type path
   (** The type of paths to constants. *)
 

--- a/src/loop/expr_intf.ml
+++ b/src/loop/expr_intf.ml
@@ -10,6 +10,7 @@ module type S = sig
   type ty
   type ty_var
   type ty_cst
+  type ty_def
 
   type term
   type term_var
@@ -26,6 +27,7 @@ module type Print = sig
   val ty : Format.formatter -> ty -> unit
   val ty_var : Format.formatter -> ty_var -> unit
   val ty_cst : Format.formatter -> ty_cst -> unit
+  val ty_def : Format.formatter -> ty_def -> unit
 
   val term : Format.formatter -> term -> unit
   val term_var : Format.formatter -> term_var -> unit

--- a/src/loop/typer.mli
+++ b/src/loop/typer.mli
@@ -60,6 +60,7 @@ module Make
      with type ty := Expr.ty
       and type ty_var := Expr.ty_var
       and type ty_cst := Expr.ty_cst
+      and type ty_def := Expr.ty_def
       and type term := Expr.term
       and type term_var := Expr.term_var
       and type term_cst := Expr.term_cst
@@ -70,6 +71,7 @@ module Make
       and type ty := Expr.ty
       and type ty_var := Expr.ty_var
       and type ty_cst := Expr.ty_cst
+      and type ty_def := Expr.ty_def
       and type term := Expr.term
       and type term_var := Expr.term_var
       and type term_cst := Expr.term_cst
@@ -79,6 +81,7 @@ module Make
        and type ty := Expr.ty
        and type ty_var := Expr.ty_var
        and type ty_cst := Expr.ty_cst
+       and type ty_def := Expr.ty_def
        and type term := Expr.term
        and type term_var := Expr.term_var
        and type term_cst := Expr.term_cst

--- a/src/loop/typer_intf.ml
+++ b/src/loop/typer_intf.ml
@@ -7,6 +7,7 @@ module type Types = sig
   type ty
   type ty_var
   type ty_cst
+  type ty_def
 
   type term
   type term_var
@@ -48,7 +49,7 @@ module type Typer = sig
     state -> input:input -> ?loc:Dolmen.Std.Loc.t ->
     ?attrs:Dolmen.Std.Term.t list -> Dolmen.Std.Statement.defs ->
     state * [
-     | `Type_def of Dolmen.Std.Id.t * ty_cst * ty_var list * ty
+     | `Type_alias of Dolmen.Std.Id.t * ty_cst * ty_var list * ty
      | `Term_def of Dolmen.Std.Id.t * term_cst * ty_var list * term_var list * term
      | `Instanceof of Dolmen.Std.Id.t * term_cst * ty list * ty_var list * term_var list * term
     ] list
@@ -57,7 +58,7 @@ module type Typer = sig
     state -> input:input -> ?loc:Dolmen.Std.Loc.t ->
     ?attrs:Dolmen.Std.Term.t list -> Dolmen.Std.Statement.decls ->
     state * [
-      | `Type_decl of ty_cst
+      | `Type_decl of ty_cst * ty_def option
       | `Term_decl of term_cst
     ] list
 
@@ -125,6 +126,7 @@ module type Typer_Full = sig
      and type ty := Dolmen.Std.Expr.ty
      and type ty_var := Dolmen.Std.Expr.ty_var
      and type ty_cst := Dolmen.Std.Expr.ty_cst
+     and type ty_def := Dolmen.Std.Expr.ty_def
      and type term := Dolmen.Std.Expr.term
      and type term_var := Dolmen.Std.Expr.term_var
      and type term_cst := Dolmen.Std.Expr.term_cst
@@ -170,7 +172,7 @@ module type S = sig
   (** Wrapper around statements. It records implicit type declarations. *)
 
   type decl = [
-    | `Type_decl of ty_cst
+    | `Type_decl of ty_cst * ty_def option
     | `Term_decl of term_cst
   ]
   (** The type of top-level type declarations. *)
@@ -181,7 +183,7 @@ module type S = sig
   (** A list of type declarations. *)
 
   type def = [
-    | `Type_def of Dolmen.Std.Id.t * ty_cst * ty_var list * ty
+    | `Type_alias of Dolmen.Std.Id.t * ty_cst * ty_var list * ty
     | `Term_def of Dolmen.Std.Id.t * term_cst * ty_var list * term_var list * term
     | `Instanceof of Dolmen.Std.Id.t * term_cst * ty list * ty_var list * term_var list * term
   ]

--- a/src/model/loop.ml
+++ b/src/model/loop.ml
@@ -220,6 +220,7 @@ module Make
       and type ty := Dolmen.Std.Expr.ty
       and type ty_var := Dolmen.Std.Expr.ty_var
       and type ty_cst := Dolmen.Std.Expr.ty_cst
+      and type ty_def := Dolmen.Std.Expr.ty_def
       and type term := Dolmen.Std.Expr.term
       and type term_var := Dolmen.Std.Expr.term_var
       and type term_cst := Dolmen.Std.Expr.term_cst
@@ -290,7 +291,7 @@ module Make
   let pack_abstract_defs ~loc ~(file:  _ file) typed_defs =
     let contents =
       List.filter_map (function
-          | `Type_def _ -> None
+          | `Type_alias _ -> None
           | `Instanceof _ -> None (* TODO: warning/error ? *)
           | `Term_def (_id, cst, ty_params, term_params, body) ->
             let func = Dolmen.Std.Expr.Term.lam (ty_params, term_params) body in
@@ -304,7 +305,7 @@ module Make
     List.fold_left2 (fun (st, model) (parsed : Dolmen.Std.Statement.def) def ->
         let loc = Dolmen.Std.Loc.{ file = file.loc; loc = parsed.loc; } in
         match def with
-        | `Type_def _ ->
+        | `Type_alias _ ->
           (State.error ~file ~loc st type_def_in_model (), model)
         | `Term_def (_id, cst, ty_params, term_params, body) ->
           let func = Dolmen.Std.Expr.Term.lam (ty_params, term_params) body in

--- a/src/typecheck/intf.ml
+++ b/src/typecheck/intf.ml
@@ -21,6 +21,7 @@ module type Formulas = sig
   type ty
   type ty_var
   type ty_cst
+  type ty_def
 
   type term
   type term_var
@@ -628,7 +629,7 @@ module type Formulas = sig
   val decls :
     env -> ?attrs:Dolmen.Std.Term.t list ->
     Dolmen.Std.Statement.decls -> [
-      | `Type_decl of ty_cst
+      | `Type_decl of ty_cst * ty_def option
       | `Term_decl of term_cst
     ] list
   (** Parse a list of potentially mutually recursive declarations. *)
@@ -637,7 +638,7 @@ module type Formulas = sig
     ?mode:[`Create_id | `Use_declared_id] ->
     env -> ?attrs:Dolmen.Std.Term.t list ->
     Dolmen.Std.Statement.defs -> [
-      | `Type_def of Dolmen.Std.Id.t * ty_cst * ty_var list * ty
+      | `Type_alias of Dolmen.Std.Id.t * ty_cst * ty_var list * ty
       | `Term_def of Dolmen.Std.Id.t * term_cst * ty_var list * term_var list * term
       | `Instanceof of Dolmen.Std.Id.t * term_cst * ty list * ty_var list * term_var list * term
     ] list

--- a/src/typecheck/tff.ml
+++ b/src/typecheck/tff.ml
@@ -15,6 +15,7 @@ module Make
      with type ty := Ty.t
       and type ty_var := Ty.Var.t
       and type ty_const := Ty.Const.t
+      and type ty_def := Ty.def
       and type 'a tag := 'a Tag.t
       and type path := Dolmen.Std.Path.t)
 = struct

--- a/src/typecheck/tff.mli
+++ b/src/typecheck/tff.mli
@@ -15,6 +15,7 @@ module Make
      with type ty := Ty.t
       and type ty_var := Ty.Var.t
       and type ty_const := Ty.Const.t
+      and type ty_def := Ty.def
       and type 'a tag := 'a Tag.t
       and type path := Dolmen.Std.Path.t)
   : S with module Tag = Tag

--- a/src/typecheck/tff_intf.ml
+++ b/src/typecheck/tff_intf.ml
@@ -20,6 +20,7 @@ module type S = sig
     with type ty := Ty.t
      and type ty_var := Ty.Var.t
      and type ty_const := Ty.Const.t
+     and type ty_def := Ty.def
      and type 'a tag := 'a Tag.t
      and type path := Dolmen.Std.Path.t
 
@@ -27,6 +28,7 @@ module type S = sig
     with type ty := Ty.t
      and type ty_var := Ty.Var.t
      and type ty_cst := Ty.Const.t
+     and type ty_def := Ty.def
      and type term := T.t
      and type term_var := T.Var.t
      and type term_cst := T.Const.t

--- a/src/typecheck/thf.mli
+++ b/src/typecheck/thf.mli
@@ -15,6 +15,7 @@ module Make
      with type ty := Ty.t
       and type ty_var := Ty.Var.t
       and type ty_const := Ty.Const.t
+      and type ty_def := Ty.def
       and type 'a tag := 'a Tag.t
       and type path := Dolmen.Std.Path.t)
   : S with module Tag = Tag

--- a/src/typecheck/thf_intf.ml
+++ b/src/typecheck/thf_intf.ml
@@ -20,6 +20,7 @@ module type S = sig
     with type ty := Ty.t
      and type ty_var := Ty.Var.t
      and type ty_const := Ty.Const.t
+     and type ty_def := Ty.def
      and type 'a tag := 'a Tag.t
      and type path := Dolmen.Std.Path.t
 
@@ -27,6 +28,7 @@ module type S = sig
     with type ty := Ty.t
      and type ty_var := Ty.Var.t
      and type ty_cst := Ty.Const.t
+     and type ty_def := Ty.def
      and type term := T.t
      and type term_var := T.Var.t
      and type term_cst := T.Const.t


### PR DESCRIPTION
Unfortunately, due to all the functors, this invovles quite a bit of code, and to get clean code, required some interface changes.