### PR TITLE
Make the unknown logic fatal by default

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,8 @@ next
 
 ### UI
 
+- Make the unknown logic fatal by default, and simply enabled
+  in non-strict mode (PR#XXX)
 - Add the `--check-flow` option to checks coherence of sequences
   of statements (PR#135)
 - Ensure stability of error codes for the `dolmen` binary

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,7 +10,7 @@ next
 ### UI
 
 - Make the unknown logic fatal by default, and simply enabled
-  in non-strict mode (PR#XXX)
+  in non-strict mode (PR#158)
 - Add the `--check-flow` option to checks coherence of sequences
   of statements (PR#135)
 - Ensure stability of error codes for the `dolmen` binary

--- a/src/bin/options.ml
+++ b/src/bin/options.ml
@@ -327,8 +327,14 @@ let reports_opts strict warn_modifiers =
   let conf = Dolmen_loop.Report.Conf.mk ~default:Enabled in
   let conf =
     if not strict then conf
-    else Dolmen_loop.Report.Conf.fatal conf
+    else begin
+      let fatal warn conf = Dolmen_loop.Report.Conf.fatal conf warn in
+      conf
+      |> fatal
         (`Warning (Dolmen_loop.Report.Any_warn Dolmen_loop.Typer.almost_linear))
+      |> fatal
+        (`Warning (Dolmen_loop.Report.Any_warn Dolmen_loop.Typer.unknown_logic))
+    end
   in
   let res =
     List.fold_left (fun conf l ->

--- a/src/loop/typer.mli
+++ b/src/loop/typer.mli
@@ -30,6 +30,8 @@ val typer_state : ty_state -> T.state
 val almost_linear : string Report.Warning.t
 (** Almost linear warning. *)
 
+val unknown_logic : string Report.Warning.t
+(** Unknown logic warning *)
 
 
 (** {2 Typechecker Functor} *)


### PR DESCRIPTION
Defaulting to the `ALL` logic comes with problems (most notably since it enables both `ints` and `reals`, literals such as `1` cannot be used anymore as `reals), and warnings can often get lost because of other warnings (particularly the unused variable one).