### PR TITLE
Add support for prelude files

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -44,6 +44,9 @@ next
 - Add the `check` function in `typer.ml`/`typer_intf.ml`
 - Add `update` and `update_opt` in `State` (PR#156)
 - Print type definitions in the printer of typed statements (PR#157)
+- Prelude statements have been removed and replaced with prelude files (PR#160)
+- `Typer.additional_builtins` is now a `State.key` and takes the current state
+  and language as arguments (PR#160)
 
 ### Model
 

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ top:
 doc:
 	dune build $(FLAGS) @doc
 
-gentests: $(wildcard tests/**/*)
+gentests: $(filter-out $(wildcard tests/**/*.t/**/*),$(wildcard tests/**/*))
 	dune exec -- tools/gentests.exe tests/
 
 test: gentests

--- a/doc/tuto.md
+++ b/doc/tuto.md
@@ -57,10 +57,11 @@ let test file =
     |> State.init
        ~debug:false ~report_style:Contextual ~max_warn:max_int
        ~reports:(Dolmen_loop.Report.Conf.mk ~default:Enabled)
-       ~logic_file ~response_file
+       ~response_file
        (* these limits are ignored in this example; to actually enforce
           the limits, one has to use the `run` function from `Dolmen_loop.Pipeline` *)
        ~time_limit:0. ~size_limit:0.
+    |> State.set State.logic_file logic_file
     |> Typer_aux.init
     |> Typer.init ~type_check:true
   in

--- a/doc/type.md
+++ b/doc/type.md
@@ -21,21 +21,22 @@ let state =
   |> State.init
      ~debug:false ~report_style:Regular ~max_warn:max_int
      ~reports:(Dolmen_loop.Report.Conf.mk ~default:Enabled)
-     ~logic_file ~response_file
+     ~response_file
      (* these limits are ignored in this example; to actually enforce
         the limits, one has to use the `run` function from `Dolmen_loop.Pipeline` *)
      ~time_limit:0. ~size_limit:0.
+  |> State.set State.logic_file logic_file
   |> Typer_aux.init
   |> Typer.init ~type_check:true
 
 (* We can add some custom builtin theories to type extensions if we want *)
-let () =
+let state =
   (* We define a dummy builtin theory that does nothing *)
-  let new_builtin _env _symbol = `Not_found in
+  let new_builtins _state _lang _env _symbol = `Not_found in
   (* We add it to the builtins used during typechecking (in addition to
      all the theories that will naturally be used depending on the `set-logic`
      statement) *)
-  Typer_aux.additional_builtins := new_builtin
+  State.set Typer_aux.additional_builtins new_builtins state
 
 (* Now we can iter on all the parsed statements *)
 let () =

--- a/src/bin/main.ml
+++ b/src/bin/main.ml
@@ -33,15 +33,14 @@ let finally st e =
   | Some (bt,exn) ->
     handle_exn st bt exn
 
-let run st =
+let run st preludes logic_file =
   if Loop.State.get Loop.State.debug st then begin
     Dolmen.Std.Expr.Print.print_index := true;
     ()
   end;
-  let st, g =
+  let g =
     try
-      Loop.Parser.parse_logic [] st
-        (Loop.State.get Loop.State.logic_file st)
+      Loop.Parser.parse_logic ~preludes logic_file
     with exn ->
       let bt = Printexc.get_raw_backtrace () in
       handle_exn st bt exn
@@ -137,8 +136,8 @@ let () =
     exit 0
   | Error (`Parse | `Term | `Exn) ->
     exit Cmdliner.Cmd.Exit.cli_error
-  | Ok (`Ok Run { state }) ->
-    run state
+  | Ok (`Ok Run { state ; preludes; logic_file }) ->
+    run state preludes logic_file
   | Ok (`Ok Doc { report; conf; }) ->
     doc conf report
   | Ok (`Ok List_reports { conf; }) ->

--- a/src/loop/parser_intf.ml
+++ b/src/loop/parser_intf.ml
@@ -33,11 +33,17 @@ module type S = sig
   *)
 
   val parse_logic :
-    Dolmen.Std.Statement.t list -> state -> Logic.language State.file ->
-    state * (state -> state * Dolmen.Std.Statement.t option)
-  (** Parsing function. Reads a list of prelude statements, and the state and
-      returns a tuple of the new state (including the detected input language),
-      together with a statement generator. *)
+    ?preludes:Logic.language State.file list -> Logic.language State.file ->
+    (state -> state * Dolmen.Std.Statement.t option)
+  (** Parsing function. Builds a statement generator from a file.
+
+      The prelude files in [preludes] must not have a [`Stdin] source, and are
+      parsed first. They may have a different language than the main file, and
+      do not influence language detection for the main file.
+
+      @before 0.9 The type was more complicated.
+      @before 0.9 Prelude files were not supported, and the [preludes] argument
+      did not exist. *)
 
   val parse_response :
     Dolmen.Std.Answer.t list -> state -> Response.language State.file ->

--- a/src/loop/state.ml
+++ b/src/loop/state.ml
@@ -201,7 +201,6 @@ let init
     ?cur_warn:(cur_warn_value=0)
     ~time_limit:time_limit_value
     ~size_limit:size_limit_value
-    ~logic_file:logic_file_value
     ~response_file:response_file_value
     st =
   st
@@ -213,7 +212,6 @@ let init
   |> set cur_warn cur_warn_value
   |> set time_limit time_limit_value
   |> set size_limit size_limit_value
-  |> set logic_file logic_file_value
   |> set response_file response_file_value
 
 (* State and locations *)
@@ -333,5 +331,3 @@ let warn ?file ?loc st warn payload =
           Report.Warning.print (warn, payload)
           Report.Warning.print_hints (warn, payload)
     end
-
-

--- a/src/lsp/loop.ml
+++ b/src/lsp/loop.ml
@@ -35,7 +35,7 @@ let finally st e =
     let res = handle_exn st exn in
     raise (Finished res)
 
-let process prelude path opt_contents =
+let process preludes path opt_contents =
   let dir = Filename.dirname path in
   let file = Filename.basename path in
   let l_file : _ State.file = {
@@ -56,7 +56,7 @@ let process prelude path opt_contents =
     |> State.init
       ~debug:false ~report_style:Regular ~reports
       ~max_warn:max_int ~time_limit:0. ~size_limit:max_float
-      ~logic_file:l_file ~response_file:r_file
+      ~response_file:r_file
     |> Parser.init ~syntax_error_ref:false
     |> Typer.init
     |> Typer_Pipe.init ~type_check:true
@@ -66,7 +66,7 @@ let process prelude path opt_contents =
       ~header_lang_version:None
   in
   try
-    let st, g = Parser.parse_logic prelude st l_file in
+    let g = Parser.parse_logic ~preludes l_file in
     let open Pipeline in
     let st = run ~finally g st (
         (fix (op ~name:"expand" Parser.expand) (
@@ -80,4 +80,3 @@ let process prelude path opt_contents =
   with
   | Finished res -> res
   | exn -> handle_exn st exn
-

--- a/src/lsp/server.ml
+++ b/src/lsp/server.ml
@@ -36,7 +36,8 @@ let preprocess_uri uri =
 let mk_prelude files =
   List.map (
     fun f ->
-      Dolmen_std.Statement.include_ f []
+      let dir, file = Dolmen_loop.State.split_input (`File f) in
+      Dolmen_loop.State.mk_file dir file
   ) files
 
 class dolmen_lsp_server =
@@ -95,7 +96,3 @@ class dolmen_lsp_server =
       notify_back#send_diagnostic []
 
   end
-
-
-
-

--- a/tests/cram.t/prelude.ae
+++ b/tests/cram.t/prelude.ae
@@ -1,0 +1,1 @@
+function twice(x : int) : int = x + x

--- a/tests/cram.t/prelude.smt2
+++ b/tests/cram.t/prelude.smt2
@@ -1,0 +1,2 @@
+(set-logic QF_LIA)
+(define-fun twice ((x Int)) Int (+ x x))

--- a/tests/cram.t/prelude.zf
+++ b/tests/cram.t/prelude.zf
@@ -1,0 +1,1 @@
+val twice : int -> int.

--- a/tests/cram.t/run.t
+++ b/tests/cram.t/run.t
@@ -1,0 +1,72 @@
+First we check that all the files are errors without preludes:
+
+  $ dolmen twice.ae
+  File "twice.ae", line 1, character 8-13:
+  1 | goal g: twice(2) = 4
+              ^^^^^
+  Error Unbound identifier: `twice`
+  [4]
+
+  $ dolmen twice.smt2
+  File "twice.smt2", line 2, character 19-24:
+  2 | (assert (distinct (twice 2) 4))
+                         ^^^^^
+  Error Unbound identifier: `twice`
+  [4]
+
+  $ dolmen thrice.smt2
+  File "thrice.smt2", line 2, character 19-25:
+  2 | (assert (distinct (thrice 2) 6))
+                         ^^^^^^
+  Error Unbound identifier: `thrice`
+  [4]
+
+Now we check that everything works with .ae preludes, except for thrice.smt2
+that uses an undefined function:
+
+  $ dolmen --prelude prelude.ae twice.ae
+
+  $ dolmen --prelude prelude.ae twice.smt2
+
+  $ dolmen --prelude prelude.ae thrice.smt2
+  File "thrice.smt2", line 2, character 19-25:
+  2 | (assert (distinct (thrice 2) 6))
+                         ^^^^^^
+  Error Unbound identifier: `thrice`
+  [4]
+
+And also with .zf preludes, for good measure:
+
+  $ dolmen --prelude prelude.zf twice.ae
+
+  $ dolmen --prelude prelude.zf twice.smt2
+
+  $ dolmen --prelude prelude.zf thrice.smt2
+  File "thrice.smt2", line 2, character 19-25:
+  2 | (assert (distinct (thrice 2) 6))
+                         ^^^^^^
+  Error Unbound identifier: `thrice`
+  [4]
+
+  $ dolmen --prelude prelude.smt2 twice.ae
+
+For smt2 preludes there are obtuse set-logic warnings, which is a bit
+unfortunate. Probably not worth fixing, at least until someone actually wants
+to use smt2 preludes.
+
+  $ dolmen --prelude prelude.smt2 twice.smt2
+  File "twice.smt2", line 1, character 0-18:
+  1 | (set-logic QF_LIA)
+      ^^^^^^^^^^^^^^^^^^
+  Warning Logic was already set at line 1, character 0-18
+
+  $ dolmen --prelude prelude.smt2 thrice.smt2
+  File "thrice.smt2", line 1, character 0-18:
+  1 | (set-logic QF_LIA)
+      ^^^^^^^^^^^^^^^^^^
+  Warning Logic was already set at line 1, character 0-18
+  File "thrice.smt2", line 2, character 19-25:
+  2 | (assert (distinct (thrice 2) 6))
+                         ^^^^^^
+  Error Unbound identifier: `thrice`
+  [4]

--- a/tests/cram.t/thrice.smt2
+++ b/tests/cram.t/thrice.smt2
@@ -1,0 +1,3 @@
+(set-logic QF_LIA)
+(assert (distinct (thrice 2) 6))
+(check-sat)

--- a/tests/cram.t/twice.ae
+++ b/tests/cram.t/twice.ae
@@ -1,0 +1,1 @@
+goal g: twice(2) = 4

--- a/tests/cram.t/twice.smt2
+++ b/tests/cram.t/twice.smt2
@@ -1,0 +1,3 @@
+(set-logic QF_LIA)
+(assert (distinct (twice 2) 4))
+(check-sat)

--- a/tests/dune
+++ b/tests/dune
@@ -1,0 +1,3 @@
+(cram
+  (package dolmen_bin)
+  (deps %{bin:dolmen}))

--- a/tools/gentests.ml
+++ b/tools/gentests.ml
@@ -110,7 +110,7 @@ let scan_folder path =
       List.sort String.compare folders
     | "." | ".." ->
       aux files folders h
-    | s ->
+    | s when Filename.extension s <> ".t" ->
       let f = Filename.concat path s in
       let stat = Unix.stat f in
       begin match stat.st_kind with
@@ -118,6 +118,7 @@ let scan_folder path =
         | Unix.S_DIR -> aux files (s :: folders) h
         | _ -> aux files folders h
       end
+    | _ -> aux files folders h
   in
   aux [] [] handle
 


### PR DESCRIPTION
This improves Dolmen's prelude support by allowing to provide preludes as files, rather than as statements.

The prelude files are parsed separately from the main file, and can use a different language from the main file. The `logic_file` is reset to the appropriate file during statement generation to ensure that the typer always uses the right language.

Since a single pipe is now expected to potentially include statements from different languages, the `additional_builtins` in the typer is passed the current language as an additional argument, allowing to define language-specific additional builtins. Since this is already a breaking change, `additional_builtins` is also changed from a reference to a `State` key for consistency with the rest of Dolmen's API.