### PR TITLE
Don't load all preludes if one of them is opened

### DIFF
--- a/src/lsp/loop.ml
+++ b/src/lsp/loop.ml
@@ -38,6 +38,18 @@ let finally st e =
 let process preludes path opt_contents =
   let dir = Filename.dirname path in
   let file = Filename.basename path in
+  let preludes =
+    let rec aux l =
+      match l with
+      | [] -> []
+      | State.{ dir = d; source = `File f; _ } :: _
+        when String.equal f file && String.equal dir d -> []
+      (* When the opened file is one of the prelude files, ignore it and the
+         following prelude files. *)
+      | h :: t -> h :: aux t
+    in
+    aux preludes
+  in
   let l_file : _ State.file = {
     lang = None; mode = None; dir;
     loc = Dolmen.Std.Loc.mk_file "";

--- a/src/lsp/server.ml
+++ b/src/lsp/server.ml
@@ -34,7 +34,7 @@ let preprocess_uri uri =
   else uri
 
 let mk_prelude files =
-  List.map (
+  List.rev_map (
     fun f ->
       let dir, file = Dolmen_loop.State.split_input (`File f) in
       Dolmen_loop.State.mk_file dir file

--- a/src/lsp/server.ml
+++ b/src/lsp/server.ml
@@ -8,17 +8,17 @@ exception ServerError of string
 let parse_settings settings =
   match settings with
   | `Assoc [ "preludes", `List l ] ->
-    List.fold_left (
-      fun acc s ->
+    List.map (
+      fun s ->
         match s with
-        | `String f -> f :: acc
+        | `String f -> f
         | _ ->
           raise (ServerError (
               Format.asprintf
                 "Expected a path to a prelude file as a string, \
                  instead got %a@."
                 Yojson.Safe.pp s))
-    ) [] l
+    ) l
   | _ ->
     raise (ServerError (
         Format.asprintf
@@ -34,7 +34,7 @@ let preprocess_uri uri =
   else uri
 
 let mk_prelude files =
-  List.rev_map (
+  List.map (
     fun f ->
       let dir, file = Dolmen_loop.State.split_input (`File f) in
       Dolmen_loop.State.mk_file dir file


### PR DESCRIPTION
Makes it possible to open prelude files without the typer complaining about multiple definitions. (and load the other prelude files which were defined before the one that was opened)