### PR TITLE
Run `realpath` on the paths of LSP prelude files

### DIFF
--- a/src/lsp/server.ml
+++ b/src/lsp/server.ml
@@ -11,7 +11,7 @@ let parse_settings settings =
     List.map (
       fun s ->
         match s with
-        | `String f -> f
+        | `String f -> Unix.realpath f
         | _ ->
           raise (ServerError (
               Format.asprintf


### PR DESCRIPTION
To make all paths absolute, the server can't find them otherwise.