### PR TITLE
Fix broken `Loc.compact` function

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,12 @@ next
   This should not affect any current use, since only SMT-LIB2 model
   verification is supported and it does not have goals.
 
+### API
+
+- Fix the implementation of `Loc.compact` which was broken and useless
+  in practice. The new version takes a file (metadata) and a full loc
+  and returns a compact loc. (PR#229)
+
 
 v0.10
 -----

--- a/src/standard/loc.ml
+++ b/src/standard/loc.ml
@@ -244,19 +244,18 @@ let loc file c : loc =
 
 let full_loc { file; loc = l; } = loc file l
 
-let compact (t : loc) =
-  let file = mk_file t.file in
+let compact file t : t =
   let start_line_offset = Vec.get file.table t.start_line in
   let start_offset = start_line_offset + t.start_column + 1 in
   let stop_line_offset = Vec.get file.table t.stop_line in
   let stop_offset = stop_line_offset + t.stop_column + 1 in
   let length = stop_offset - start_offset in
-  file, mk_compact start_offset length
+  mk_compact start_offset length
 
 (* File path normalization *)
 (* ************************************************************************* *)
 
-(** It turns out that in most cases, using forward slashes in patsh actually
+(** It turns out that in most cases, using forward slashes in paths actually
     work on Windows, see
     https://learn.microsoft.com/en-us/archive/blogs/larryosterman/why-is-the-dos-path-character
 

--- a/src/standard/loc.mli
+++ b/src/standard/loc.mli
@@ -76,11 +76,12 @@ val loc : file -> t -> loc
 val full_loc : full -> loc
 (** Return a complete location from a compact location and meta-data. *)
 
-val compact : loc -> file * t
+val compact : file -> loc -> t
 (** Compactify a full location into a compact representation. *)
 
 val lexing_positions : loc -> Lexing.position * Lexing.position
 (** Return the pair of lexing positions corresponding to a location. *)
+
 
 (** {2 Printing locations} *)
 


### PR DESCRIPTION
Fix a broken implementation of `Loc.compact`, see the explanation in the Changes file for more details.