### PR TITLE
Hierarchical builtins

### DIFF
--- a/src/model/arith.ml
+++ b/src/model/arith.ml
@@ -1,0 +1,90 @@
+
+(* This file is free software, part of dolmen. See file "LICENSE" for more information *)
+
+(* Builtin dispatch *)
+(* ************************************************************************* *)
+
+let builtins ~eval env (cst : Dolmen.Std.Expr.Term.Const.t) =
+  match cst.builtin with
+  | Dolmen.Std.Builtin.Arith blt ->
+    begin match blt with
+      (* Integers *)
+      | Int -> assert false (* Types are not evaluated *)
+      | Integer i -> Int.integer i
+      | Lt `Int -> Int.lt ~cst
+      | Gt `Int -> Int.gt ~cst
+      | Geq `Int -> Int.geq ~cst
+      | Leq `Int -> Int.leq ~cst
+      | Minus `Int -> Int.minus ~cst
+      | Add `Int -> Int.add ~cst
+      | Sub `Int -> Int.sub ~cst
+      | Mul `Int -> Int.mul ~cst
+      | Pow `Int -> Int.pow ~cst
+      | Div_e `Int -> Int.div_e ~cst ~eval ~env
+      | Div_t `Int -> Int.div_t ~cst
+      | Div_f `Int -> Int.div_f ~cst
+      | Modulo_e `Int -> Int.mod_e ~cst ~eval ~env
+      | Modulo_t `Int -> Int.mod_t ~cst
+      | Modulo_f `Int -> Int.mod_f ~cst
+      | Divisible -> Int.divisible ~cst
+      | Abs -> Int.abs ~cst
+      | Is_int `Int -> Int.is_int ~cst
+      | Is_rat `Int -> Int.is_rat ~cst
+      | Floor `Int -> Int.floor ~cst
+      | Ceiling `Int -> Int.ceiling ~cst
+      | Truncate `Int -> Int.truncate ~cst
+      | Round `Int -> Int.round ~cst
+      (* Rationals *)
+      | Rat -> assert false (* Types are not evaluated *)
+      | Rational i -> Rat.rational i
+      | Lt `Rat -> Rat.lt ~cst
+      | Gt `Rat -> Rat.gt ~cst
+      | Geq `Rat -> Rat.geq ~cst
+      | Leq `Rat -> Rat.leq ~cst
+      | Minus `Rat -> Rat.minus ~cst
+      | Add `Rat -> Rat.add ~cst
+      | Sub `Rat -> Rat.sub ~cst
+      | Mul `Rat -> Rat.mul ~cst
+      | Div `Rat -> Rat.div ~cst
+      | Div_e `Rat -> Rat.div_e ~cst
+      | Div_t `Rat -> Rat.div_t ~cst
+      | Div_f `Rat -> Rat.div_f ~cst
+      | Modulo_e `Rat -> Rat.mod_e ~cst
+      | Modulo_t `Rat -> Rat.mod_t ~cst
+      | Modulo_f `Rat -> Rat.mod_f ~cst
+      | Floor `Rat -> Rat.floor ~cst
+      | Floor_to_int `Rat -> Rat.floor_to_int ~cst
+      | Ceiling `Rat -> Rat.ceiling ~cst
+      | Truncate `Rat -> Rat.truncate ~cst
+      | Round `Rat -> Rat.round ~cst
+      | Is_int `Rat -> Rat.is_int ~cst
+      | Is_rat `Rat -> Rat.is_rat ~cst
+      (* Reals *)
+      | Real -> assert false (* Types are not evaluated *)
+      | Decimal i -> Real.decimal i
+      | Lt `Real -> Real.lt ~cst
+      | Gt `Real -> Real.gt ~cst
+      | Geq `Real -> Real.geq ~cst
+      | Leq `Real -> Real.leq ~cst
+      | Minus `Real -> Real.minus ~cst
+      | Add `Real -> Real.add ~cst
+      | Sub `Real -> Real.sub ~cst
+      | Mul `Real -> Real.mul ~cst
+      | Div `Real -> Real.div ~cst ~env ~eval
+      | Div_e `Real -> Real.div_e ~cst
+      | Div_t `Real -> Real.div_t ~cst
+      | Div_f `Real -> Real.div_f ~cst
+      | Modulo_e `Real -> Real.mod_e ~cst
+      | Modulo_t `Real -> Real.mod_t ~cst
+      | Modulo_f `Real -> Real.mod_f ~cst
+      | Is_rat `Real -> Real.is_rat ~cst
+      | Floor `Real -> Real.floor ~cst
+      | Floor_to_int `Real -> Real.floor_to_int ~cst
+      | Ceiling `Real -> Real.ceiling ~cst
+      | Truncate `Real -> Real.truncate ~cst
+      | Round `Real -> Real.round ~cst
+      | Is_int `Real -> Real.is_int ~cst
+      | Pow `Real -> Real.pow ~cst
+    end
+  | _ -> None
+

--- a/src/model/arith.mli
+++ b/src/model/arith.mli
@@ -1,0 +1,8 @@
+
+(* This file is free software, part of dolmen. See file "LICENSE" for more information *)
+
+(** {2 Builtins} *)
+(** ************************************************************************ *)
+
+val builtins : Env.builtins
+(** builtins for floating-points *)

--- a/src/model/array.ml
+++ b/src/model/array.ml
@@ -103,9 +103,13 @@ let store array key value =
 
 let builtins ~eval:_ _ (cst : Dolmen.Std.Expr.Term.Const.t) =
   match cst.builtin with
-  | B.Const -> Some (Fun.mk_clos @@ Fun.fun_1 ~cst const)
-  | B.Select -> Some (Fun.mk_clos @@ Fun.fun_2 ~cst select)
-  | B.Store -> Some (Fun.mk_clos @@ Fun.fun_3 ~cst store)
+  | Dolmen.Std.Builtin.Array blt ->
+    begin match blt with
+      | T -> assert false (* Types are not evaluated *)
+      | Const -> Some (Fun.mk_clos @@ Fun.fun_1 ~cst const)
+      | Select -> Some (Fun.mk_clos @@ Fun.fun_2 ~cst select)
+      | Store -> Some (Fun.mk_clos @@ Fun.fun_3 ~cst store)
+    end
   | _ -> None
 
 

--- a/src/model/bitv.ml
+++ b/src/model/bitv.ml
@@ -128,113 +128,117 @@ let binary_overflow ~cst ~signed ~size op =
 let builtins ~eval:_ _ (cst : Dolmen.Std.Expr.Term.Const.t) =
   let extract n t = Z.extract t 0 n in
   match cst.builtin with
-  | B.Bitvec s ->
-    Some (mk (String.length s) (Z.of_string_base 2 s))
-  | B.Bitv_of_int { n } -> int2bv ~cst ~size:n
-  | B.Bitv_to_int { n; signed } -> bv2int ~cst ~signed ~size:n
-  | B.Bitv_concat { n; m } ->
-    op2 ~cst ~size:(n + m) (concat n m)
-  | B.Bitv_extract { n; i; j } ->
-    op1 ~cst ~size:(i - j + 1) (fun a -> Z.extract (ubitv n a) j (i - j + 1))
-  | B.Bitv_repeat { n; k } ->
-    op1 ~cst ~size:(n * k) (fun a -> repeat n k (ubitv n a))
-  | B.Bitv_zero_extend { n; k } ->
-    op1 ~cst ~size:(n + k) (ubitv n)
-  | B.Bitv_sign_extend { n; k } ->
-    op1 ~cst ~size:(n + k) (fun a -> extract (n + k) (sbitv n a))
-  | B.Bitv_rotate_left { n; i } ->
-    op1 ~cst ~size:n (fun a -> rotate_left n i (ubitv n a))
-  | B.Bitv_rotate_right { n; i } ->
-    op1 ~cst ~size:n (fun a -> rotate_right n i (ubitv n a))
-  | B.Bitv_not n ->
-    op1 ~cst ~size:n (fun a -> extract n (Z.lognot (ubitv n a)))
-  | B.Bitv_and n ->
-    op2 ~cst ~size:n (fun a b -> Z.logand (ubitv n a) (ubitv n b))
-  | B.Bitv_or n ->
-    op2 ~cst ~size:n (fun a b ->
-        from_bitv n (Z.logor (ubitv n a) (ubitv n b)))
-  | B.Bitv_nand n ->
-    op2 ~cst ~size:n (fun a b ->
-        extract n (Z.lognot (Z.logand (ubitv n a) (ubitv n b))))
-  | B.Bitv_nor n ->
-    op2 ~cst ~size:n (fun a b ->
-        extract n (Z.lognot (Z.logor (ubitv n a) (ubitv n b))))
-  | B.Bitv_xor n ->
-    op2 ~cst ~size:n (fun a b -> extract n (Z.logxor (ubitv n a) (ubitv n b)))
-  | B.Bitv_xnor n ->
-    op2 ~cst ~size:n (fun a b ->
-        extract n (Z.logxor (ubitv n a) (Z.lognot (ubitv n b))))
-  | B.Bitv_comp n ->
-    op2 ~cst ~size:n (fun a b ->
-        if Z.equal (ubitv n a) (ubitv n b)
-        then extract 1 Z.minus_one
-        else from_bitv 1 Z.zero)
-  | B.Bitv_neg n ->
-    op1 ~cst ~size:n (fun a ->
-        extract n (Z.sub (Z.shift_left Z.one n) (ubitv n a)))
-  | B.Bitv_add n ->
-    op2 ~cst ~size:n (fun a b -> extract n (Z.add (ubitv n a) (ubitv n b)))
-  | B.Bitv_sub n ->
-    op2 ~cst ~size:n (fun a b -> extract n (Z.sub (ubitv n a) (ubitv n b)))
-  | B.Bitv_mul n ->
-    op2 ~cst ~size:n (fun a b -> extract n (Z.mul (ubitv n a) (ubitv n b)))
-  | B.Bitv_udiv n ->
-    op2 ~cst ~size:n (fun a b ->
-        let b = ubitv n b in
-        if Z.equal b Z.zero then extract n Z.minus_one
-        else extract n (Z.div (ubitv n a) b))
-  | B.Bitv_urem n ->
-    op2 ~cst ~size:n (fun a b ->
-        let b = ubitv n b in
-        if Z.equal b Z.zero then from_bitv n (ubitv n a)
-        else extract n (Z.rem (ubitv n a) b))
-  | B.Bitv_sdiv n ->
-    op2 ~cst ~size:n (fun a b ->
-        let b = sbitv n b in
-        let a = sbitv n a in
-        if Z.equal b Z.zero then
-          if Z.sign a >= 0 then extract n Z.minus_one else extract n Z.one
-        else extract n (Z.div a b))
-  | B.Bitv_srem n ->
-    op2 ~cst ~size:n (fun a b ->
-        let b = sbitv n b in
-        if Z.equal b Z.zero then from_bitv n (ubitv n a)
-        else extract n (Z.rem (sbitv n a) b))
-  | B.Bitv_smod n ->
-    op2 ~cst ~size:n (fun a b ->
-        let b = sbitv n b in
-        if Z.equal b Z.zero then from_bitv n (ubitv n a)
-        else begin
-          let a = sbitv n a in
-          extract n (Z.sub a (Z.mul (Z.fdiv a b) b))
-        end)
-  | B.Bitv_shl n ->
-    op2 ~cst ~size:n (fun a b ->
-        let b = ubitv n b in
-        if Z.leq (Z.of_int n) b then from_bitv n Z.zero
-        else extract n (Z.shift_left (ubitv n a) (Z.to_int b)))
-  | B.Bitv_lshr n ->
-    op2 ~cst ~size:n (fun a b ->
-        let b = ubitv n b in
-        if Z.leq (Z.of_int n) b then from_bitv n Z.zero
-        else extract n (Z.shift_right (ubitv n a) (Z.to_int b)))
-  | B.Bitv_ashr n ->
-    op2 ~cst ~size:n (fun a b ->
-        let b = ubitv n b in
-        let b = if Z.leq (Z.of_int n) b then n else Z.to_int b in
-        extract n (Z.shift_right (sbitv n a) b))
-  | B.Bitv_ult n -> cmp ~cst (fun a b -> Z.lt (ubitv n a) (ubitv n b))
-  | B.Bitv_ule n -> cmp ~cst (fun a b -> Z.leq (ubitv n a) (ubitv n b))
-  | B.Bitv_ugt n -> cmp ~cst (fun a b -> Z.gt (ubitv n a) (ubitv n b))
-  | B.Bitv_uge n -> cmp ~cst (fun a b -> Z.geq (ubitv n a) (ubitv n b))
-  | B.Bitv_slt n -> cmp ~cst (fun a b -> Z.lt (sbitv n a) (sbitv n b))
-  | B.Bitv_sle n -> cmp ~cst (fun a b -> Z.leq (sbitv n a) (sbitv n b))
-  | B.Bitv_sgt n -> cmp ~cst (fun a b -> Z.gt (sbitv n a) (sbitv n b))
-  | B.Bitv_sge n -> cmp ~cst (fun a b -> Z.geq (sbitv n a) (sbitv n b))
-  | B.Bitv_overflow_neg { n; } -> neg_overflow ~cst ~size:n
-  | B.Bitv_overflow_add { n; signed; } -> binary_overflow ~cst ~size:n ~signed Z.add
-  | B.Bitv_overflow_sub { n; signed; } -> binary_overflow ~cst ~size:n ~signed Z.sub
-  | B.Bitv_overflow_mul { n; signed; } -> binary_overflow ~cst ~size:n ~signed Z.mul
-  | B.Bitv_overflow_div { n; } -> binary_overflow ~cst ~size:n ~signed:true Z.div
+  | Dolmen.Std.Builtin.Bitv blt ->
+    begin match blt with
+      | T _ -> assert false (* Types are not evaluated *)
+      | Binary_lit s ->
+        Some (mk (String.length s) (Z.of_string_base 2 s))
+      | Of_int { n } -> int2bv ~cst ~size:n
+      | To_int { n; signed } -> bv2int ~cst ~signed ~size:n
+      | Concat { n; m } ->
+        op2 ~cst ~size:(n + m) (concat n m)
+      | Extract { n; i; j } ->
+        op1 ~cst ~size:(i - j + 1) (fun a -> Z.extract (ubitv n a) j (i - j + 1))
+      | Repeat { n; k } ->
+        op1 ~cst ~size:(n * k) (fun a -> repeat n k (ubitv n a))
+      | Zero_extend { n; k } ->
+        op1 ~cst ~size:(n + k) (ubitv n)
+      | Sign_extend { n; k } ->
+        op1 ~cst ~size:(n + k) (fun a -> extract (n + k) (sbitv n a))
+      | Rotate_left { n; i } ->
+        op1 ~cst ~size:n (fun a -> rotate_left n i (ubitv n a))
+      | Rotate_right { n; i } ->
+        op1 ~cst ~size:n (fun a -> rotate_right n i (ubitv n a))
+      | Not n ->
+        op1 ~cst ~size:n (fun a -> extract n (Z.lognot (ubitv n a)))
+      | And n ->
+        op2 ~cst ~size:n (fun a b -> Z.logand (ubitv n a) (ubitv n b))
+      | Or n ->
+        op2 ~cst ~size:n (fun a b ->
+            from_bitv n (Z.logor (ubitv n a) (ubitv n b)))
+      | Nand n ->
+        op2 ~cst ~size:n (fun a b ->
+            extract n (Z.lognot (Z.logand (ubitv n a) (ubitv n b))))
+      | Nor n ->
+        op2 ~cst ~size:n (fun a b ->
+            extract n (Z.lognot (Z.logor (ubitv n a) (ubitv n b))))
+      | Xor n ->
+        op2 ~cst ~size:n (fun a b -> extract n (Z.logxor (ubitv n a) (ubitv n b)))
+      | Xnor n ->
+        op2 ~cst ~size:n (fun a b ->
+            extract n (Z.logxor (ubitv n a) (Z.lognot (ubitv n b))))
+      | Comp n ->
+        op2 ~cst ~size:n (fun a b ->
+            if Z.equal (ubitv n a) (ubitv n b)
+            then extract 1 Z.minus_one
+            else from_bitv 1 Z.zero)
+      | Neg n ->
+        op1 ~cst ~size:n (fun a ->
+            extract n (Z.sub (Z.shift_left Z.one n) (ubitv n a)))
+      | Add n ->
+        op2 ~cst ~size:n (fun a b -> extract n (Z.add (ubitv n a) (ubitv n b)))
+      | Sub n ->
+        op2 ~cst ~size:n (fun a b -> extract n (Z.sub (ubitv n a) (ubitv n b)))
+      | Mul n ->
+        op2 ~cst ~size:n (fun a b -> extract n (Z.mul (ubitv n a) (ubitv n b)))
+      | Udiv n ->
+        op2 ~cst ~size:n (fun a b ->
+            let b = ubitv n b in
+            if Z.equal b Z.zero then extract n Z.minus_one
+            else extract n (Z.div (ubitv n a) b))
+      | Urem n ->
+        op2 ~cst ~size:n (fun a b ->
+            let b = ubitv n b in
+            if Z.equal b Z.zero then from_bitv n (ubitv n a)
+            else extract n (Z.rem (ubitv n a) b))
+      | Sdiv n ->
+        op2 ~cst ~size:n (fun a b ->
+            let b = sbitv n b in
+            let a = sbitv n a in
+            if Z.equal b Z.zero then
+              if Z.sign a >= 0 then extract n Z.minus_one else extract n Z.one
+            else extract n (Z.div a b))
+      | Srem n ->
+        op2 ~cst ~size:n (fun a b ->
+            let b = sbitv n b in
+            if Z.equal b Z.zero then from_bitv n (ubitv n a)
+            else extract n (Z.rem (sbitv n a) b))
+      | Smod n ->
+        op2 ~cst ~size:n (fun a b ->
+            let b = sbitv n b in
+            if Z.equal b Z.zero then from_bitv n (ubitv n a)
+            else begin
+              let a = sbitv n a in
+              extract n (Z.sub a (Z.mul (Z.fdiv a b) b))
+            end)
+      | Shl n ->
+        op2 ~cst ~size:n (fun a b ->
+            let b = ubitv n b in
+            if Z.leq (Z.of_int n) b then from_bitv n Z.zero
+            else extract n (Z.shift_left (ubitv n a) (Z.to_int b)))
+      | Lshr n ->
+        op2 ~cst ~size:n (fun a b ->
+            let b = ubitv n b in
+            if Z.leq (Z.of_int n) b then from_bitv n Z.zero
+            else extract n (Z.shift_right (ubitv n a) (Z.to_int b)))
+      | Ashr n ->
+        op2 ~cst ~size:n (fun a b ->
+            let b = ubitv n b in
+            let b = if Z.leq (Z.of_int n) b then n else Z.to_int b in
+            extract n (Z.shift_right (sbitv n a) b))
+      | Ult n -> cmp ~cst (fun a b -> Z.lt (ubitv n a) (ubitv n b))
+      | Ule n -> cmp ~cst (fun a b -> Z.leq (ubitv n a) (ubitv n b))
+      | Ugt n -> cmp ~cst (fun a b -> Z.gt (ubitv n a) (ubitv n b))
+      | Uge n -> cmp ~cst (fun a b -> Z.geq (ubitv n a) (ubitv n b))
+      | Slt n -> cmp ~cst (fun a b -> Z.lt (sbitv n a) (sbitv n b))
+      | Sle n -> cmp ~cst (fun a b -> Z.leq (sbitv n a) (sbitv n b))
+      | Sgt n -> cmp ~cst (fun a b -> Z.gt (sbitv n a) (sbitv n b))
+      | Sge n -> cmp ~cst (fun a b -> Z.geq (sbitv n a) (sbitv n b))
+      | Overflow_neg { n; } -> neg_overflow ~cst ~size:n
+      | Overflow_add { n; signed; } -> binary_overflow ~cst ~size:n ~signed Z.add
+      | Overflow_sub { n; signed; } -> binary_overflow ~cst ~size:n ~signed Z.sub
+      | Overflow_mul { n; signed; } -> binary_overflow ~cst ~size:n ~signed Z.mul
+      | Overflow_div { n; } -> binary_overflow ~cst ~size:n ~signed:true Z.div
+    end
   | _ -> None
 

--- a/src/model/bitv.ml
+++ b/src/model/bitv.ml
@@ -149,61 +149,61 @@ let builtins ~eval:_ _ (cst : Dolmen.Std.Expr.Term.Const.t) =
         op1 ~cst ~size:n (fun a -> rotate_left n i (ubitv n a))
       | Rotate_right { n; i } ->
         op1 ~cst ~size:n (fun a -> rotate_right n i (ubitv n a))
-      | Not n ->
+      | Not {n} ->
         op1 ~cst ~size:n (fun a -> extract n (Z.lognot (ubitv n a)))
-      | And n ->
+      | And {n} ->
         op2 ~cst ~size:n (fun a b -> Z.logand (ubitv n a) (ubitv n b))
-      | Or n ->
+      | Or {n} ->
         op2 ~cst ~size:n (fun a b ->
             from_bitv n (Z.logor (ubitv n a) (ubitv n b)))
-      | Nand n ->
+      | Nand {n} ->
         op2 ~cst ~size:n (fun a b ->
             extract n (Z.lognot (Z.logand (ubitv n a) (ubitv n b))))
-      | Nor n ->
+      | Nor {n} ->
         op2 ~cst ~size:n (fun a b ->
             extract n (Z.lognot (Z.logor (ubitv n a) (ubitv n b))))
-      | Xor n ->
+      | Xor {n} ->
         op2 ~cst ~size:n (fun a b -> extract n (Z.logxor (ubitv n a) (ubitv n b)))
-      | Xnor n ->
+      | Xnor {n} ->
         op2 ~cst ~size:n (fun a b ->
             extract n (Z.logxor (ubitv n a) (Z.lognot (ubitv n b))))
-      | Comp n ->
+      | Comp {n} ->
         op2 ~cst ~size:n (fun a b ->
             if Z.equal (ubitv n a) (ubitv n b)
             then extract 1 Z.minus_one
             else from_bitv 1 Z.zero)
-      | Neg n ->
+      | Neg {n} ->
         op1 ~cst ~size:n (fun a ->
             extract n (Z.sub (Z.shift_left Z.one n) (ubitv n a)))
-      | Add n ->
+      | Add {n} ->
         op2 ~cst ~size:n (fun a b -> extract n (Z.add (ubitv n a) (ubitv n b)))
-      | Sub n ->
+      | Sub {n} ->
         op2 ~cst ~size:n (fun a b -> extract n (Z.sub (ubitv n a) (ubitv n b)))
-      | Mul n ->
+      | Mul {n} ->
         op2 ~cst ~size:n (fun a b -> extract n (Z.mul (ubitv n a) (ubitv n b)))
-      | Udiv n ->
+      | Udiv {n} ->
         op2 ~cst ~size:n (fun a b ->
             let b = ubitv n b in
             if Z.equal b Z.zero then extract n Z.minus_one
             else extract n (Z.div (ubitv n a) b))
-      | Urem n ->
+      | Urem {n} ->
         op2 ~cst ~size:n (fun a b ->
             let b = ubitv n b in
             if Z.equal b Z.zero then from_bitv n (ubitv n a)
             else extract n (Z.rem (ubitv n a) b))
-      | Sdiv n ->
+      | Sdiv {n} ->
         op2 ~cst ~size:n (fun a b ->
             let b = sbitv n b in
             let a = sbitv n a in
             if Z.equal b Z.zero then
               if Z.sign a >= 0 then extract n Z.minus_one else extract n Z.one
             else extract n (Z.div a b))
-      | Srem n ->
+      | Srem {n} ->
         op2 ~cst ~size:n (fun a b ->
             let b = sbitv n b in
             if Z.equal b Z.zero then from_bitv n (ubitv n a)
             else extract n (Z.rem (sbitv n a) b))
-      | Smod n ->
+      | Smod {n} ->
         op2 ~cst ~size:n (fun a b ->
             let b = sbitv n b in
             if Z.equal b Z.zero then from_bitv n (ubitv n a)
@@ -211,29 +211,29 @@ let builtins ~eval:_ _ (cst : Dolmen.Std.Expr.Term.Const.t) =
               let a = sbitv n a in
               extract n (Z.sub a (Z.mul (Z.fdiv a b) b))
             end)
-      | Shl n ->
+      | Shl {n} ->
         op2 ~cst ~size:n (fun a b ->
             let b = ubitv n b in
             if Z.leq (Z.of_int n) b then from_bitv n Z.zero
             else extract n (Z.shift_left (ubitv n a) (Z.to_int b)))
-      | Lshr n ->
+      | Lshr {n} ->
         op2 ~cst ~size:n (fun a b ->
             let b = ubitv n b in
             if Z.leq (Z.of_int n) b then from_bitv n Z.zero
             else extract n (Z.shift_right (ubitv n a) (Z.to_int b)))
-      | Ashr n ->
+      | Ashr {n} ->
         op2 ~cst ~size:n (fun a b ->
             let b = ubitv n b in
             let b = if Z.leq (Z.of_int n) b then n else Z.to_int b in
             extract n (Z.shift_right (sbitv n a) b))
-      | Ult n -> cmp ~cst (fun a b -> Z.lt (ubitv n a) (ubitv n b))
-      | Ule n -> cmp ~cst (fun a b -> Z.leq (ubitv n a) (ubitv n b))
-      | Ugt n -> cmp ~cst (fun a b -> Z.gt (ubitv n a) (ubitv n b))
-      | Uge n -> cmp ~cst (fun a b -> Z.geq (ubitv n a) (ubitv n b))
-      | Slt n -> cmp ~cst (fun a b -> Z.lt (sbitv n a) (sbitv n b))
-      | Sle n -> cmp ~cst (fun a b -> Z.leq (sbitv n a) (sbitv n b))
-      | Sgt n -> cmp ~cst (fun a b -> Z.gt (sbitv n a) (sbitv n b))
-      | Sge n -> cmp ~cst (fun a b -> Z.geq (sbitv n a) (sbitv n b))
+      | Ult {n} -> cmp ~cst (fun a b -> Z.lt (ubitv n a) (ubitv n b))
+      | Ule {n} -> cmp ~cst (fun a b -> Z.leq (ubitv n a) (ubitv n b))
+      | Ugt {n} -> cmp ~cst (fun a b -> Z.gt (ubitv n a) (ubitv n b))
+      | Uge {n} -> cmp ~cst (fun a b -> Z.geq (ubitv n a) (ubitv n b))
+      | Slt {n} -> cmp ~cst (fun a b -> Z.lt (sbitv n a) (sbitv n b))
+      | Sle {n} -> cmp ~cst (fun a b -> Z.leq (sbitv n a) (sbitv n b))
+      | Sgt {n} -> cmp ~cst (fun a b -> Z.gt (sbitv n a) (sbitv n b))
+      | Sge {n} -> cmp ~cst (fun a b -> Z.geq (sbitv n a) (sbitv n b))
       | Overflow_neg { n; } -> neg_overflow ~cst ~size:n
       | Overflow_add { n; signed; } -> binary_overflow ~cst ~size:n ~signed Z.add
       | Overflow_sub { n; signed; } -> binary_overflow ~cst ~size:n ~signed Z.sub

--- a/src/model/bool.ml
+++ b/src/model/bool.ml
@@ -36,16 +36,29 @@ let fun_n f ~cst =
 
 let builtins ~eval:_ _ (cst : Dolmen.Std.Expr.Term.Const.t) =
   match cst.builtin with
-  | B.True -> Some true_v
-  | B.False -> Some false_v
-  | B.Neg -> Some (fun1 ~cst not)
-  | B.And -> Some (fun_n ~cst @@ fun l -> List.fold_left (&&) true l)
-  | B.Or -> Some (fun_n ~cst @@ fun l -> List.fold_left (||) false l)
-  | B.Nand -> Some (fun2 ~cst (fun b1 b2 -> not (b1 && b2)))
-  | B.Nor -> Some (fun2 ~cst (fun b1 b2 -> not (b1 || b2)))
-  | B.Xor -> Some (fun2 ~cst (fun b1 b2 -> b1 <> b2))
-  | B.Imply -> Some (fun2 ~cst (fun b1 b2 -> not b1 || b2))
-  | B.Implied -> Some (fun2 ~cst (fun b1 b2 -> not b2 || b1))
-  | B.Equiv -> Some (fun2 ~cst (fun b1 b2 -> b1 = b2))
+  | B.Prop blt ->
+    begin match blt with
+      | T -> assert false (* Types are not evlauated *)
+      | True -> Some true_v
+      | False -> Some false_v
+      | Neg -> Some (fun1 ~cst not)
+      | And -> Some (fun_n ~cst @@ fun l -> List.fold_left (&&) true l)
+      | Or -> Some (fun_n ~cst @@ fun l -> List.fold_left (||) false l)
+      | Nand -> Some (fun2 ~cst (fun b1 b2 -> not (b1 && b2)))
+      | Nor -> Some (fun2 ~cst (fun b1 b2 -> not (b1 || b2)))
+      | Xor -> Some (fun2 ~cst (fun b1 b2 -> b1 <> b2))
+      | Imply -> Some (fun2 ~cst (fun b1 b2 -> not b1 || b2))
+      | Implied -> Some (fun2 ~cst (fun b1 b2 -> not b2 || b1))
+      | Equiv -> Some (fun2 ~cst (fun b1 b2 -> b1 = b2))
+      | Ite ->
+        Some (Fun.mk_clos @@ Fun.fun_lazy ~cst (fun env eval args ->
+            match args with
+            | [cond; then_; else_] ->
+              if Value.extract_exn ~ops (eval env cond)
+              then eval env then_
+              else eval env else_
+            | _ -> assert false
+          ))
+    end
   | _ -> None
 

--- a/src/model/core.ml
+++ b/src/model/core.ml
@@ -22,7 +22,7 @@ let builtins ~eval:_ _ (cst : E.Term.Const.t) =
   match cst.builtin with
   | B.Equal -> Some (Fun.fun_n ~cst all_equals)
   | B.Distinct -> Some (Fun.fun_n ~cst distinct)
-  | B.Ite ->
+  | B.Prop Ite ->
     Some (Fun.mk_clos @@ Fun.fun_lazy ~cst (fun env eval args ->
         match args with
         | [cond; then_; else_] ->

--- a/src/model/core.ml
+++ b/src/model/core.ml
@@ -22,14 +22,5 @@ let builtins ~eval:_ _ (cst : E.Term.Const.t) =
   match cst.builtin with
   | B.Equal -> Some (Fun.fun_n ~cst all_equals)
   | B.Distinct -> Some (Fun.fun_n ~cst distinct)
-  | B.Prop Ite ->
-    Some (Fun.mk_clos @@ Fun.fun_lazy ~cst (fun env eval args ->
-        match args with
-        | [cond; then_; else_] ->
-          if Value.extract_exn ~ops:Bool.ops (eval env cond)
-          then eval env then_
-          else eval env else_
-        | _ -> assert false
-      ))
   | _ -> None
 

--- a/src/model/dune
+++ b/src/model/dune
@@ -22,7 +22,7 @@
     ; Model checking
     Value Model Env Eval Ext
     ; Builtins
-    Adt Array Bool Core Fun Int Rat Real Bitv Fp Coercion
+    Adt Array Bool Core Fun Int Rat Real Arith Bitv Fp Coercion
     ; Loop Pipe
     Loop
   )

--- a/src/model/eval.ml
+++ b/src/model/eval.ml
@@ -64,7 +64,7 @@ and eval_cst env (c : Cst.t) =
       | Some value -> value
       | None -> raise (Undefined_constant c)
     end
-  | B.Map_app ->
+  | B.Map App ->
     Fun.(mk_clos @@ fun_lazy ~cst:c (fun env _eval args ->
         match args with
         | [f; x] -> eval_apply env f [] [x]

--- a/src/model/fp.ml
+++ b/src/model/fp.ml
@@ -94,7 +94,7 @@ let min_max ~eval env ~cmp ~cst =
 let nearest_no_tie x =
   (* the tie break should be handled before *)
   assert (not (Z.equal x.Q.den (Z.of_int 2)));
-  Int.ceil (Q.sub x (Q.make Z.one (Z.of_int 2)))
+  Int.raw_ceil (Q.sub x (Q.make Z.one (Z.of_int 2)))
 
 
 let toIntegral mode q =
@@ -102,172 +102,176 @@ let toIntegral mode q =
   | Mode.NE ->
     if Z.equal (Z.of_int 2) q.Q.den then
       (* denominator is 2 so in the middle *)
-      let r = Int.floor q in
+      let r = Int.raw_floor q in
       (if Z.is_even r then r else Z.succ r)
     else
       (nearest_no_tie q)
   | Mode.NA ->
     if Z.equal (Z.of_int 2) q.Q.den then
       (* denominator is 2 so in the middle *)
-      let r = if Z.sign q.Q.num < 0 then Int.floor q else Int.ceil q in
+      let r = if Z.sign q.Q.num < 0 then Int.raw_floor q else Int.raw_ceil q in
       r
     else
       (nearest_no_tie q)
-  | Mode.ZR -> (Int.truncate q)
-  | Mode.DN -> (Int.floor q)
-  | Mode.UP -> (Int.ceil q)
+  | Mode.ZR -> (Int.raw_truncate q)
+  | Mode.DN -> (Int.raw_floor q)
+  | Mode.UP -> (Int.raw_ceil q)
 
 
 let builtins ~eval env (cst : Dolmen.Std.Expr.Term.Const.t) =
   match cst.builtin with
-  | B.RoundNearestTiesToEven -> Some (Value.mk ~ops:ops_rm Mode.NE)
-  | B.RoundNearestTiesToAway -> Some (Value.mk ~ops:ops_rm Mode.NA)
-  | B.RoundTowardPositive -> Some (Value.mk ~ops:ops_rm Mode.UP)
-  | B.RoundTowardNegative -> Some (Value.mk ~ops:ops_rm Mode.DN)
-  | B.RoundTowardZero -> Some (Value.mk ~ops:ops_rm Mode.ZR)
-  | B.Real_to_fp (ew, prec) ->
-    Some (Fun.mk_clos @@ Fun.fun_2 ~cst (fun m r ->
-        check ~ew ~mw:(prec - 1);
-        mk (f_of_q ~ew ~mw:(prec - 1) (mode m) (Real.get r))))
-  | B.Fp_to_fp (_ew1, _prec1, ew2, prec2) ->
-    Some (Fun.mk_clos @@ Fun.fun_2 ~cst
-            (fun m f1 -> mk @@ f_round ~ew:ew2 ~mw:(prec2 - 1) (mode m) (fp f1)))
-  | B.Sbv_to_fp (n, ew, prec) ->
-    Some (Fun.mk_clos @@ Fun.fun_2 ~cst (fun m bv ->
-        mk @@ f_of_q ~ew ~mw:(prec - 1) (mode m) (Q.of_bigint (Bitv.sbitv n bv))))
-  | B.Ubv_to_fp (n, ew, prec) ->
-    Some (Fun.mk_clos @@ Fun.fun_2 ~cst (fun m bv ->
-        mk @@ f_of_q ~ew ~mw:(prec - 1) (mode m) (Q.of_bigint (Bitv.ubitv n bv))))
-  | B.Fp (ew, prec) ->
-    Some (Fun.mk_clos @@ Fun.fun_3 ~cst (fun bvs bve bvm ->
-        mk @@
-        f_of_bits ~ew ~mw:(prec - 1)
-          (Z.logor
-             (Z.logor
-                (Z.shift_left
-                   (Bitv.ubitv 1 bvs)
-                   (ew + prec - 1))
-                (Z.shift_left
-                   (Bitv.ubitv ew bve)
-                   (prec - 1)))
-             (Bitv.ubitv (prec - 1) bvm))))
-  | B.Ieee_format_to_fp (ew, prec) ->
-    Some (Fun.mk_clos @@ Fun.fun_1 ~cst (fun bv ->
-        mk @@
-        f_of_bits ~ew ~mw:(prec - 1) (Bitv.ubitv (ew + prec) bv)))
-  | B.To_real (_ew, _prec) ->
-    Some (Fun.mk_clos @@ Fun.fun_1 ~cst (fun f -> Real.mk @@ (F.to_q (fp f))))
-  | B.Plus_infinity (ew, prec) ->
-    Some (mk @@ f_inf ~ew ~mw:(prec - 1) false)
-  | B.Minus_infinity (ew, prec) ->
-    Some (mk @@ f_inf ~ew ~mw:(prec - 1) true)
-  | B.NaN (ew, prec) ->
-    Some (mk @@ f_nan ~ew ~mw:(prec - 1))
-  | B.Plus_zero (ew, prec) ->
-    Some (mk @@ f_zero ~ew ~mw:(prec - 1) false)
-  | B.Minus_zero (ew, prec) ->
-    Some (mk @@ f_zero ~ew ~mw:(prec - 1) true)
-  | B.Fp_add (_ew, _prec) ->
-    op2_mode ~cst F.add
-  | B.Fp_sub (_ew, _prec) ->
-    op2_mode ~cst F.sub
-  | B.Fp_mul (_ew, _prec) ->
-    op2_mode ~cst F.mul
-  | B.Fp_abs (_ew, _prec) ->
-    op1 ~cst F.abs
-  | B.Fp_neg (_ew, _prec) ->
-    op1 ~cst F.neg
-  | B.Fp_sqrt (_ew, _prec) ->
-    op1_mode ~cst F.sqrt
-  | B.Fp_div (_ew, _prec) ->
-    op2_mode ~cst F.div
-  | B.Fp_fma (_ew, _prec) ->
-    Some (Fun.mk_clos @@ Fun.fun_4 ~cst (fun m x y z ->
-        mk @@ F.fma (mode m) (fp x) (fp y) (fp z)))
-  | B.Fp_eq (_ew, _prec) ->
-    cmp ~cst F.eq
-  | B.Fp_leq (_ew, _prec) ->
-    cmp ~cst F.le
-  | B.Fp_lt (_ew, _prec) ->
-    cmp ~cst F.lt
-  | B.Fp_geq (_ew, _prec) ->
-    cmp ~cst F.ge
-  | B.Fp_gt (_ew, _prec) ->
-    cmp ~cst F.gt
-  | B.Fp_isInfinite (_ew, _prec) ->
-    test ~cst F.is_infinite
-  | B.Fp_isZero (_ew, _prec) ->
-    test ~cst F.is_zero
-  | B.Fp_isNaN (_ew, _prec) ->
-    test ~cst F.is_nan
-  | B.Fp_isNegative (_ew, _prec) ->
-    test ~cst F.is_negative
-  | B.Fp_isPositive (_ew, _prec) ->
-    test ~cst F.is_positive
-  | B.Fp_isNormal (_ew, _prec) ->
-    test ~cst F.is_normal
-  | B.Fp_isSubnormal (_ew, _prec) ->
-    test ~cst F.is_subnormal
-  | B.Fp_rem (ew,prec) ->
-    Some (Fun.mk_clos @@ Fun.fun_2 ~cst (fun f g ->
-        let f = fp f in
-        let g = fp g in
-        let mode = Farith.Mode.NE in
-        let mw = prec - 1 in
-        match F.classify f, F.classify g with
-        | (NaN | PInf | NInf), _ -> mk (F.nan ~ew ~mw)
-        | _, (NaN | PZero | NZero) -> mk (F.nan ~ew ~mw)
-        | _, (PInf | NInf) -> mk f
-        | (PZero | NZero | PNormal | NNormal | PSubn | NSubn) ,
-          (PNormal | NNormal | PSubn | NSubn) ->
-          let qf = F.to_q f and qg = F.to_q g in
-          let y = toIntegral mode (Q.div qf qg) in
-          let x = Q.sub qf (Q.mul qg (Q.of_bigint y)) in
-          mk (round_q ~neg:(F.is_negative f) mode ~ew ~mw x)
-      ))
-  | B.Fp_roundToIntegral (ew,prec) ->
-    Some (Fun.mk_clos @@ Fun.fun_2 ~cst (fun m f ->
-        let f = fp f in
-        let mode = mode m in
-        let mw = prec - 1 in
-        match F.classify f with
-        | (NaN | PInf | NInf | PZero | NZero) -> mk f
-        | (PNormal | NNormal | PSubn | NSubn) ->
-          let q = F.to_q f in
-          let n = toIntegral mode q in
-          mk (round_q ~neg:(F.is_negative f) ~mw ~ew mode (Q.of_bigint n))
-      ))
-  | B.Fp_min (_ew,_prec) -> min_max ~eval env ~cmp:F.lt ~cst
-  | B.Fp_max (_ew,_prec) -> min_max ~eval env ~cmp:F.gt ~cst
-  | B.To_ubv (_ew,_prec,size) ->
-    Some (Fun.mk_clos @@ Fun.fun_2 ~cst (fun m f ->
-        let f' = fp f in
-        let mode = mode m in
-        match F.classify f' with
-        | (NaN | PInf | NInf) ->
-          Fun.corner_case ~eval env cst [] [m; f]
-        | (PNormal | NNormal | PSubn | NSubn | PZero | NZero) ->
-          let q = F.to_q f' in
-          let n = toIntegral mode q in
-          if Z.sign n >= 0 && Z.numbits n <= size then
-            Bitv.mk size n
-          else
-            Fun.corner_case ~eval env cst [] [m; f]
-      ))
-  | B.To_sbv (_ew,_prec,size) ->
-    Some (Fun.mk_clos @@ Fun.fun_2 ~cst (fun m f ->
-        let f' = fp f in
-        let mode = mode m in
-        match F.classify f' with
-        | (NaN | PInf | NInf) ->
-          Fun.corner_case ~eval env cst [] [m; f]
-        | (PNormal | NNormal | PSubn | NSubn | PZero | NZero) ->
-          let q = F.to_q f' in
-          let n = toIntegral mode q in
-          let n' = Z.extract n 0 size in
-          if Z.equal n (Z.signed_extract n' 0 size) then
-            Bitv.mk size n'
-          else
-            Fun.corner_case ~eval env cst [] [m; f]
-      ))
+  | Dolmen.Std.Builtin.Float blt ->
+    begin match blt with
+      | T _ | RoundingMode -> assert false (* Types are not evaluated *)
+      | RoundNearestTiesToEven -> Some (Value.mk ~ops:ops_rm Mode.NE)
+      | RoundNearestTiesToAway -> Some (Value.mk ~ops:ops_rm Mode.NA)
+      | RoundTowardPositive -> Some (Value.mk ~ops:ops_rm Mode.UP)
+      | RoundTowardNegative -> Some (Value.mk ~ops:ops_rm Mode.DN)
+      | RoundTowardZero -> Some (Value.mk ~ops:ops_rm Mode.ZR)
+      | Of_real (ew, prec) ->
+        Some (Fun.mk_clos @@ Fun.fun_2 ~cst (fun m r ->
+            check ~ew ~mw:(prec - 1);
+            mk (f_of_q ~ew ~mw:(prec - 1) (mode m) (Real.get r))))
+      | To_fp (_ew1, _prec1, ew2, prec2) ->
+        Some (Fun.mk_clos @@ Fun.fun_2 ~cst
+                (fun m f1 -> mk @@ f_round ~ew:ew2 ~mw:(prec2 - 1) (mode m) (fp f1)))
+      | Of_sbv (n, ew, prec) ->
+        Some (Fun.mk_clos @@ Fun.fun_2 ~cst (fun m bv ->
+            mk @@ f_of_q ~ew ~mw:(prec - 1) (mode m) (Q.of_bigint (Bitv.sbitv n bv))))
+      | Of_ubv (n, ew, prec) ->
+        Some (Fun.mk_clos @@ Fun.fun_2 ~cst (fun m bv ->
+            mk @@ f_of_q ~ew ~mw:(prec - 1) (mode m) (Q.of_bigint (Bitv.ubitv n bv))))
+      | Fp (ew, prec) ->
+        Some (Fun.mk_clos @@ Fun.fun_3 ~cst (fun bvs bve bvm ->
+            mk @@
+            f_of_bits ~ew ~mw:(prec - 1)
+              (Z.logor
+                 (Z.logor
+                    (Z.shift_left
+                       (Bitv.ubitv 1 bvs)
+                       (ew + prec - 1))
+                    (Z.shift_left
+                       (Bitv.ubitv ew bve)
+                       (prec - 1)))
+                 (Bitv.ubitv (prec - 1) bvm))))
+      | Ieee_format_to_fp (ew, prec) ->
+        Some (Fun.mk_clos @@ Fun.fun_1 ~cst (fun bv ->
+            mk @@
+            f_of_bits ~ew ~mw:(prec - 1) (Bitv.ubitv (ew + prec) bv)))
+      | To_real (_ew, _prec) ->
+        Some (Fun.mk_clos @@ Fun.fun_1 ~cst (fun f -> Real.mk @@ (F.to_q (fp f))))
+      | Plus_infinity (ew, prec) ->
+        Some (mk @@ f_inf ~ew ~mw:(prec - 1) false)
+      | Minus_infinity (ew, prec) ->
+        Some (mk @@ f_inf ~ew ~mw:(prec - 1) true)
+      | NaN (ew, prec) ->
+        Some (mk @@ f_nan ~ew ~mw:(prec - 1))
+      | Plus_zero (ew, prec) ->
+        Some (mk @@ f_zero ~ew ~mw:(prec - 1) false)
+      | Minus_zero (ew, prec) ->
+        Some (mk @@ f_zero ~ew ~mw:(prec - 1) true)
+      | Add (_ew, _prec) ->
+        op2_mode ~cst F.add
+      | Sub (_ew, _prec) ->
+        op2_mode ~cst F.sub
+      | Mul (_ew, _prec) ->
+        op2_mode ~cst F.mul
+      | Abs (_ew, _prec) ->
+        op1 ~cst F.abs
+      | Neg (_ew, _prec) ->
+        op1 ~cst F.neg
+      | Sqrt (_ew, _prec) ->
+        op1_mode ~cst F.sqrt
+      | Div (_ew, _prec) ->
+        op2_mode ~cst F.div
+      | Fma (_ew, _prec) ->
+        Some (Fun.mk_clos @@ Fun.fun_4 ~cst (fun m x y z ->
+            mk @@ F.fma (mode m) (fp x) (fp y) (fp z)))
+      | Eq (_ew, _prec) ->
+        cmp ~cst F.eq
+      | Leq (_ew, _prec) ->
+        cmp ~cst F.le
+      | Lt (_ew, _prec) ->
+        cmp ~cst F.lt
+      | Geq (_ew, _prec) ->
+        cmp ~cst F.ge
+      | Gt (_ew, _prec) ->
+        cmp ~cst F.gt
+      | IsInfinite (_ew, _prec) ->
+        test ~cst F.is_infinite
+      | IsZero (_ew, _prec) ->
+        test ~cst F.is_zero
+      | IsNaN (_ew, _prec) ->
+        test ~cst F.is_nan
+      | IsNegative (_ew, _prec) ->
+        test ~cst F.is_negative
+      | IsPositive (_ew, _prec) ->
+        test ~cst F.is_positive
+      | IsNormal (_ew, _prec) ->
+        test ~cst F.is_normal
+      | IsSubnormal (_ew, _prec) ->
+        test ~cst F.is_subnormal
+      | Rem (ew,prec) ->
+        Some (Fun.mk_clos @@ Fun.fun_2 ~cst (fun f g ->
+            let f = fp f in
+            let g = fp g in
+            let mode = Farith.Mode.NE in
+            let mw = prec - 1 in
+            match F.classify f, F.classify g with
+            | (NaN | PInf | NInf), _ -> mk (F.nan ~ew ~mw)
+            | _, (NaN | PZero | NZero) -> mk (F.nan ~ew ~mw)
+            | _, (PInf | NInf) -> mk f
+            | (PZero | NZero | PNormal | NNormal | PSubn | NSubn) ,
+              (PNormal | NNormal | PSubn | NSubn) ->
+              let qf = F.to_q f and qg = F.to_q g in
+              let y = toIntegral mode (Q.div qf qg) in
+              let x = Q.sub qf (Q.mul qg (Q.of_bigint y)) in
+              mk (round_q ~neg:(F.is_negative f) mode ~ew ~mw x)
+          ))
+      | RoundToIntegral (ew,prec) ->
+        Some (Fun.mk_clos @@ Fun.fun_2 ~cst (fun m f ->
+            let f = fp f in
+            let mode = mode m in
+            let mw = prec - 1 in
+            match F.classify f with
+            | (NaN | PInf | NInf | PZero | NZero) -> mk f
+            | (PNormal | NNormal | PSubn | NSubn) ->
+              let q = F.to_q f in
+              let n = toIntegral mode q in
+              mk (round_q ~neg:(F.is_negative f) ~mw ~ew mode (Q.of_bigint n))
+          ))
+      | Min (_ew,_prec) -> min_max ~eval env ~cmp:F.lt ~cst
+      | Max (_ew,_prec) -> min_max ~eval env ~cmp:F.gt ~cst
+      | To_ubv (_ew,_prec,size) ->
+        Some (Fun.mk_clos @@ Fun.fun_2 ~cst (fun m f ->
+            let f' = fp f in
+            let mode = mode m in
+            match F.classify f' with
+            | (NaN | PInf | NInf) ->
+              Fun.corner_case ~eval env cst [] [m; f]
+            | (PNormal | NNormal | PSubn | NSubn | PZero | NZero) ->
+              let q = F.to_q f' in
+              let n = toIntegral mode q in
+              if Z.sign n >= 0 && Z.numbits n <= size then
+                Bitv.mk size n
+              else
+                Fun.corner_case ~eval env cst [] [m; f]
+          ))
+      | To_sbv (_ew,_prec,size) ->
+        Some (Fun.mk_clos @@ Fun.fun_2 ~cst (fun m f ->
+            let f' = fp f in
+            let mode = mode m in
+            match F.classify f' with
+            | (NaN | PInf | NInf) ->
+              Fun.corner_case ~eval env cst [] [m; f]
+            | (PNormal | NNormal | PSubn | NSubn | PZero | NZero) ->
+              let q = F.to_q f' in
+              let n = toIntegral mode q in
+              let n' = Z.extract n 0 size in
+              if Z.equal n (Z.signed_extract n' 0 size) then
+                Bitv.mk size n'
+              else
+                Fun.corner_case ~eval env cst [] [m; f]
+          ))
+    end
   | _ -> None

--- a/src/model/fp.ml
+++ b/src/model/fp.ml
@@ -128,20 +128,20 @@ let builtins ~eval env (cst : Dolmen.Std.Expr.Term.Const.t) =
       | RoundTowardPositive -> Some (Value.mk ~ops:ops_rm Mode.UP)
       | RoundTowardNegative -> Some (Value.mk ~ops:ops_rm Mode.DN)
       | RoundTowardZero -> Some (Value.mk ~ops:ops_rm Mode.ZR)
-      | Of_real (ew, prec) ->
+      | Of_real { e = ew; s = prec; } ->
         Some (Fun.mk_clos @@ Fun.fun_2 ~cst (fun m r ->
             check ~ew ~mw:(prec - 1);
             mk (f_of_q ~ew ~mw:(prec - 1) (mode m) (Real.get r))))
-      | To_fp (_ew1, _prec1, ew2, prec2) ->
+      | To_fp { e1 = _ew1; s1 = _prec1; e2 = ew2; s2 = prec2; } ->
         Some (Fun.mk_clos @@ Fun.fun_2 ~cst
                 (fun m f1 -> mk @@ f_round ~ew:ew2 ~mw:(prec2 - 1) (mode m) (fp f1)))
-      | Of_sbv (n, ew, prec) ->
+      | Of_sbv { m = n; e = ew; s = prec; } ->
         Some (Fun.mk_clos @@ Fun.fun_2 ~cst (fun m bv ->
             mk @@ f_of_q ~ew ~mw:(prec - 1) (mode m) (Q.of_bigint (Bitv.sbitv n bv))))
-      | Of_ubv (n, ew, prec) ->
+      | Of_ubv { m = n; e = ew; s = prec; } ->
         Some (Fun.mk_clos @@ Fun.fun_2 ~cst (fun m bv ->
             mk @@ f_of_q ~ew ~mw:(prec - 1) (mode m) (Q.of_bigint (Bitv.ubitv n bv))))
-      | Fp (ew, prec) ->
+      | Fp { e = ew; s = prec; } ->
         Some (Fun.mk_clos @@ Fun.fun_3 ~cst (fun bvs bve bvm ->
             mk @@
             f_of_bits ~ew ~mw:(prec - 1)
@@ -154,64 +154,64 @@ let builtins ~eval env (cst : Dolmen.Std.Expr.Term.Const.t) =
                        (Bitv.ubitv ew bve)
                        (prec - 1)))
                  (Bitv.ubitv (prec - 1) bvm))))
-      | Ieee_format_to_fp (ew, prec) ->
+      | Ieee_format_to_fp { e = ew; s = prec; } ->
         Some (Fun.mk_clos @@ Fun.fun_1 ~cst (fun bv ->
             mk @@
             f_of_bits ~ew ~mw:(prec - 1) (Bitv.ubitv (ew + prec) bv)))
-      | To_real (_ew, _prec) ->
+      | To_real { e = _ew; s = _prec; } ->
         Some (Fun.mk_clos @@ Fun.fun_1 ~cst (fun f -> Real.mk @@ (F.to_q (fp f))))
-      | Plus_infinity (ew, prec) ->
+      | Plus_infinity { e = ew; s = prec; } ->
         Some (mk @@ f_inf ~ew ~mw:(prec - 1) false)
-      | Minus_infinity (ew, prec) ->
+      | Minus_infinity { e = ew; s = prec; } ->
         Some (mk @@ f_inf ~ew ~mw:(prec - 1) true)
-      | NaN (ew, prec) ->
+      | NaN { e = ew; s = prec; } ->
         Some (mk @@ f_nan ~ew ~mw:(prec - 1))
-      | Plus_zero (ew, prec) ->
+      | Plus_zero { e = ew; s = prec; } ->
         Some (mk @@ f_zero ~ew ~mw:(prec - 1) false)
-      | Minus_zero (ew, prec) ->
+      | Minus_zero { e = ew; s = prec; } ->
         Some (mk @@ f_zero ~ew ~mw:(prec - 1) true)
-      | Add (_ew, _prec) ->
+      | Add { e = _ew; s = _prec; } ->
         op2_mode ~cst F.add
-      | Sub (_ew, _prec) ->
+      | Sub { e = _ew; s = _prec; } ->
         op2_mode ~cst F.sub
-      | Mul (_ew, _prec) ->
+      | Mul { e = _ew; s = _prec; } ->
         op2_mode ~cst F.mul
-      | Abs (_ew, _prec) ->
+      | Abs { e = _ew; s = _prec; } ->
         op1 ~cst F.abs
-      | Neg (_ew, _prec) ->
+      | Neg { e = _ew; s = _prec; } ->
         op1 ~cst F.neg
-      | Sqrt (_ew, _prec) ->
+      | Sqrt { e = _ew; s = _prec; } ->
         op1_mode ~cst F.sqrt
-      | Div (_ew, _prec) ->
+      | Div { e = _ew; s = _prec; } ->
         op2_mode ~cst F.div
-      | Fma (_ew, _prec) ->
+      | Fma { e = _ew; s = _prec; } ->
         Some (Fun.mk_clos @@ Fun.fun_4 ~cst (fun m x y z ->
             mk @@ F.fma (mode m) (fp x) (fp y) (fp z)))
-      | Eq (_ew, _prec) ->
+      | Eq { e = _ew; s = _prec; } ->
         cmp ~cst F.eq
-      | Leq (_ew, _prec) ->
+      | Leq { e = _ew; s = _prec; } ->
         cmp ~cst F.le
-      | Lt (_ew, _prec) ->
+      | Lt { e = _ew; s = _prec; } ->
         cmp ~cst F.lt
-      | Geq (_ew, _prec) ->
+      | Geq { e = _ew; s = _prec; } ->
         cmp ~cst F.ge
-      | Gt (_ew, _prec) ->
+      | Gt { e = _ew; s = _prec; } ->
         cmp ~cst F.gt
-      | IsInfinite (_ew, _prec) ->
+      | IsInfinite { e = _ew; s = _prec; } ->
         test ~cst F.is_infinite
-      | IsZero (_ew, _prec) ->
+      | IsZero { e = _ew; s = _prec; } ->
         test ~cst F.is_zero
-      | IsNaN (_ew, _prec) ->
+      | IsNaN { e = _ew; s = _prec; } ->
         test ~cst F.is_nan
-      | IsNegative (_ew, _prec) ->
+      | IsNegative { e = _ew; s = _prec; } ->
         test ~cst F.is_negative
-      | IsPositive (_ew, _prec) ->
+      | IsPositive { e = _ew; s = _prec; } ->
         test ~cst F.is_positive
-      | IsNormal (_ew, _prec) ->
+      | IsNormal { e = _ew; s = _prec; } ->
         test ~cst F.is_normal
-      | IsSubnormal (_ew, _prec) ->
+      | IsSubnormal { e = _ew; s = _prec; } ->
         test ~cst F.is_subnormal
-      | Rem (ew,prec) ->
+      | Rem {e = ew; s = prec; } ->
         Some (Fun.mk_clos @@ Fun.fun_2 ~cst (fun f g ->
             let f = fp f in
             let g = fp g in
@@ -228,7 +228,7 @@ let builtins ~eval env (cst : Dolmen.Std.Expr.Term.Const.t) =
               let x = Q.sub qf (Q.mul qg (Q.of_bigint y)) in
               mk (round_q ~neg:(F.is_negative f) mode ~ew ~mw x)
           ))
-      | RoundToIntegral (ew,prec) ->
+      | RoundToIntegral {e = ew; s = prec; } ->
         Some (Fun.mk_clos @@ Fun.fun_2 ~cst (fun m f ->
             let f = fp f in
             let mode = mode m in
@@ -240,9 +240,9 @@ let builtins ~eval env (cst : Dolmen.Std.Expr.Term.Const.t) =
               let n = toIntegral mode q in
               mk (round_q ~neg:(F.is_negative f) ~mw ~ew mode (Q.of_bigint n))
           ))
-      | Min (_ew,_prec) -> min_max ~eval env ~cmp:F.lt ~cst
-      | Max (_ew,_prec) -> min_max ~eval env ~cmp:F.gt ~cst
-      | To_ubv (_ew,_prec,size) ->
+      | Min { e = _ew; s = _prec; } -> min_max ~eval env ~cmp:F.lt ~cst
+      | Max { e = _ew; s = _prec; } -> min_max ~eval env ~cmp:F.gt ~cst
+      | To_ubv { m = size; e = _ew; s = _prec; } ->
         Some (Fun.mk_clos @@ Fun.fun_2 ~cst (fun m f ->
             let f' = fp f in
             let mode = mode m in
@@ -257,7 +257,7 @@ let builtins ~eval env (cst : Dolmen.Std.Expr.Term.Const.t) =
               else
                 Fun.corner_case ~eval env cst [] [m; f]
           ))
-      | To_sbv (_ew,_prec,size) ->
+      | To_sbv { m = size; e = _ew; s = _prec; } ->
         Some (Fun.mk_clos @@ Fun.fun_2 ~cst (fun m f ->
             let f' = fp f in
             let mode = mode m in

--- a/src/model/fp.mli
+++ b/src/model/fp.mli
@@ -1,3 +1,4 @@
+
 (* This file is free software, part of dolmen. See file "LICENSE" for more information *)
 
 (** {2 Value definition} *)

--- a/src/model/int.mli
+++ b/src/model/int.mli
@@ -13,17 +13,47 @@ val ops : Z.t Value.ops
 val mk : Z.t -> Value.t
 (** integer value creation. *)
 
-(** {2 Builtins} *)
-(** ************************************************************************ *)
-
-val builtins : Env.builtins
-(** builtins for integers *)
-
 
 (** {2 Value helpers} *)
 (** ************************************************************************ *)
 
-val ceil : Q.t -> Z.t
-val floor : Q.t -> Z.t
-val truncate : Q.t -> Z.t
+val raw_ceil : Q.t -> Z.t
+val raw_floor : Q.t -> Z.t
+val raw_truncate : Q.t -> Z.t
 
+
+(** {2 Builtin values} *)
+(** ************************************************************************ *)
+
+val integer : string -> Value.t option
+val lt : cst:Dolmen.Std.Expr.Term.Const.t -> Value.t option
+val gt : cst:Dolmen.Std.Expr.Term.Const.t -> Value.t option
+val geq : cst:Dolmen.Std.Expr.Term.Const.t -> Value.t option
+val leq : cst:Dolmen.Std.Expr.Term.Const.t -> Value.t option
+val minus : cst:Dolmen.Std.Expr.Term.Const.t -> Value.t option
+val add : cst:Dolmen.Std.Expr.Term.Const.t -> Value.t option
+val sub : cst:Dolmen.Std.Expr.Term.Const.t -> Value.t option
+val mul : cst:Dolmen.Std.Expr.Term.Const.t -> Value.t option
+val pow : cst:Dolmen.Std.Expr.Term.Const.t -> Value.t option
+val div_e :
+  cst:Dolmen.Std.Expr.Term.Const.t ->
+  eval:(Env.t -> Dolmen.Std.Expr.Term.t -> Value.t) ->
+  env:Env.t ->
+  Value.t option
+val div_t : cst:Dolmen.Std.Expr.Term.Const.t -> Value.t option
+val div_f : cst:Dolmen.Std.Expr.Term.Const.t -> Value.t option
+val mod_e :
+  cst:Dolmen.Std.Expr.Term.Const.t ->
+  eval:(Env.t -> Dolmen.Std.Expr.Term.t -> Value.t) ->
+  env:Env.t ->
+  Value.t option
+val mod_t : cst:Dolmen.Std.Expr.Term.Const.t -> Value.t option
+val mod_f : cst:Dolmen.Std.Expr.Term.Const.t -> Value.t option
+val divisible : cst:Dolmen.Std.Expr.Term.Const.t -> Value.t option
+val abs : cst:Dolmen.Std.Expr.Term.Const.t -> Value.t option
+val floor : cst:Dolmen.Std.Expr.Term.Const.t -> Value.t option
+val ceiling : cst:Dolmen.Std.Expr.Term.Const.t -> Value.t option
+val truncate : cst:Dolmen.Std.Expr.Term.Const.t -> Value.t option
+val round : cst:Dolmen.Std.Expr.Term.Const.t -> Value.t option
+val is_int : cst:Dolmen.Std.Expr.Term.Const.t -> Value.t option
+val is_rat : cst:Dolmen.Std.Expr.Term.Const.t -> Value.t option

--- a/src/model/loop.ml
+++ b/src/model/loop.ml
@@ -271,9 +271,12 @@ module Make
       Bool.builtins;
       Core.builtins;
       Array.builtins;
+      Arith.builtins;
+      (*
       Int.builtins;
       Rat.builtins;
       Real.builtins;
+      *)
       Bitv.builtins;
       Fp.builtins;
       Coercion.builtins;

--- a/src/model/rat.mli
+++ b/src/model/rat.mli
@@ -13,6 +13,30 @@ val ops : t Value.ops
 val mk : t -> Value.t
 (** real value creation. *)
 
-val builtins : Env.builtins
-(** builtins for reals *)
+(** {2 Evluation functions} *)
+(** ************************************************************************ *)
+
+val rational : string -> Value.t option
+val lt : cst:Dolmen.Std.Expr.Term.Const.t -> Value.t option
+val gt : cst:Dolmen.Std.Expr.Term.Const.t -> Value.t option
+val geq : cst:Dolmen.Std.Expr.Term.Const.t -> Value.t option
+val leq : cst:Dolmen.Std.Expr.Term.Const.t -> Value.t option
+val minus : cst:Dolmen.Std.Expr.Term.Const.t -> Value.t option
+val add : cst:Dolmen.Std.Expr.Term.Const.t -> Value.t option
+val sub : cst:Dolmen.Std.Expr.Term.Const.t -> Value.t option
+val mul : cst:Dolmen.Std.Expr.Term.Const.t -> Value.t option
+val div : cst:Dolmen.Std.Expr.Term.Const.t -> Value.t option
+val div_e : cst:Dolmen.Std.Expr.Term.Const.t -> Value.t option
+val div_t : cst:Dolmen.Std.Expr.Term.Const.t -> Value.t option
+val div_f : cst:Dolmen.Std.Expr.Term.Const.t -> Value.t option
+val mod_e : cst:Dolmen.Std.Expr.Term.Const.t -> Value.t option
+val mod_t : cst:Dolmen.Std.Expr.Term.Const.t -> Value.t option
+val mod_f : cst:Dolmen.Std.Expr.Term.Const.t -> Value.t option
+val floor : cst:Dolmen.Std.Expr.Term.Const.t -> Value.t option
+val ceiling : cst:Dolmen.Std.Expr.Term.Const.t -> Value.t option
+val truncate : cst:Dolmen.Std.Expr.Term.Const.t -> Value.t option
+val round : cst:Dolmen.Std.Expr.Term.Const.t -> Value.t option
+val is_int : cst:Dolmen.Std.Expr.Term.Const.t -> Value.t option
+val is_rat : cst:Dolmen.Std.Expr.Term.Const.t -> Value.t option
+val floor_to_int : cst:Dolmen.Std.Expr.Term.Const.t -> Value.t option
 

--- a/src/model/real.mli
+++ b/src/model/real.mli
@@ -19,10 +19,34 @@ val get : Value.t -> Q.t
 (** Get a rational value. *)
 
 
-(** {2 Corner cases & builtins} *)
+(** {2 Builtin values} *)
 (** ************************************************************************ *)
 
-val builtins : Env.builtins
-(** builtins for reals *)
-
-
+val decimal : string -> Value.t option
+val lt : cst:Dolmen.Std.Expr.Term.Const.t -> Value.t option
+val gt : cst:Dolmen.Std.Expr.Term.Const.t -> Value.t option
+val geq : cst:Dolmen.Std.Expr.Term.Const.t -> Value.t option
+val leq : cst:Dolmen.Std.Expr.Term.Const.t -> Value.t option
+val minus : cst:Dolmen.Std.Expr.Term.Const.t -> Value.t option
+val add : cst:Dolmen.Std.Expr.Term.Const.t -> Value.t option
+val sub : cst:Dolmen.Std.Expr.Term.Const.t -> Value.t option
+val mul : cst:Dolmen.Std.Expr.Term.Const.t -> Value.t option
+val div :
+  cst:Dolmen.Std.Expr.Term.Const.t ->
+  eval:(Env.t -> Dolmen.Std.Expr.Term.t -> Value.t) ->
+  env:Env.t ->
+  Value.t option
+val div_e : cst:Dolmen.Std.Expr.Term.Const.t -> Value.t option
+val div_t : cst:Dolmen.Std.Expr.Term.Const.t -> Value.t option
+val div_f : cst:Dolmen.Std.Expr.Term.Const.t -> Value.t option
+val mod_e : cst:Dolmen.Std.Expr.Term.Const.t -> Value.t option
+val mod_t : cst:Dolmen.Std.Expr.Term.Const.t -> Value.t option
+val mod_f : cst:Dolmen.Std.Expr.Term.Const.t -> Value.t option
+val floor : cst:Dolmen.Std.Expr.Term.Const.t -> Value.t option
+val ceiling : cst:Dolmen.Std.Expr.Term.Const.t -> Value.t option
+val truncate : cst:Dolmen.Std.Expr.Term.Const.t -> Value.t option
+val round : cst:Dolmen.Std.Expr.Term.Const.t -> Value.t option
+val is_int : cst:Dolmen.Std.Expr.Term.Const.t -> Value.t option
+val is_rat : cst:Dolmen.Std.Expr.Term.Const.t -> Value.t option
+val floor_to_int : cst:Dolmen.Std.Expr.Term.Const.t -> Value.t option
+val pow : cst:Dolmen.Std.Expr.Term.Const.t -> Value.t option

--- a/src/standard/builtin.ml
+++ b/src/standard/builtin.ml
@@ -125,7 +125,7 @@ type 'a t += Array of 'a Array.t
 
 module Bitv = struct
   type _ t =
-    | T of int
+    | T of { n : int; }
     | Binary_lit of string
     | To_int of { n : int; signed : bool; }
     | Of_int of { n : int; }
@@ -136,34 +136,34 @@ module Bitv = struct
     | Sign_extend of { n : int; k : int }
     | Rotate_right of { n : int; i : int }
     | Rotate_left of { n : int; i : int }
-    | Not of int
-    | And of int
-    | Or of int
-    | Nand of int
-    | Nor of int
-    | Xor of int
-    | Xnor of int
-    | Comp of int
-    | Neg of int
-    | Add of int
-    | Sub of int
-    | Mul of int
-    | Udiv of int
-    | Urem of int
-    | Sdiv of int
-    | Srem of int
-    | Smod of int
-    | Shl of int
-    | Lshr of int
-    | Ashr of int
-    | Ult of int
-    | Ule of int
-    | Ugt of int
-    | Uge of int
-    | Slt of int
-    | Sle of int
-    | Sgt of int
-    | Sge of int
+    | Not of { n : int; }
+    | And of { n : int; }
+    | Or of { n : int; }
+    | Nand of { n : int; }
+    | Nor of { n : int; }
+    | Xor of { n : int; }
+    | Xnor of { n : int; }
+    | Comp of { n : int; }
+    | Neg of { n : int; }
+    | Add of { n : int; }
+    | Sub of { n : int; }
+    | Mul of { n : int; }
+    | Udiv of { n : int; }
+    | Urem of { n : int; }
+    | Sdiv of { n : int; }
+    | Srem of { n : int; }
+    | Smod of { n : int; }
+    | Shl of { n : int; }
+    | Lshr of { n : int; }
+    | Ashr of { n : int; }
+    | Ult of { n : int; }
+    | Ule of { n : int; }
+    | Ugt of { n : int; }
+    | Uge of { n : int; }
+    | Slt of { n : int; }
+    | Sle of { n : int; }
+    | Sgt of { n : int; }
+    | Sge of { n : int; }
     | Overflow_neg of { n : int; }
     | Overflow_add of { n : int; signed : bool; }
     | Overflow_sub of { n : int; signed : bool; }
@@ -179,51 +179,51 @@ type 'a t += Bitv of 'a Bitv.t
 
 module Float = struct
   type _ t =
-    | T of int * int
+    | T of { e : int; s : int; }
     | RoundingMode
-    | Fp of int * int
+    | Fp of { e : int; s : int; }
     | RoundNearestTiesToEven
     | RoundNearestTiesToAway
     | RoundTowardPositive
     | RoundTowardNegative
     | RoundTowardZero
-    | Plus_infinity of int * int
-    | Minus_infinity of int * int
-    | Plus_zero of int * int
-    | Minus_zero of int * int
-    | NaN of int * int
-    | Abs of int * int
-    | Neg of int * int
-    | Add of int * int
-    | Sub of int * int
-    | Mul of int * int
-    | Div of int * int
-    | Fma of int * int
-    | Sqrt of int * int
-    | Rem of int * int
-    | RoundToIntegral  of int * int
-    | Min of int * int
-    | Max of int * int
-    | Leq of int * int
-    | Lt of int * int
-    | Geq of int * int
-    | Gt of int * int
-    | Eq of int * int
-    | IsNormal of int * int
-    | IsSubnormal of int * int
-    | IsZero of int * int
-    | IsInfinite of int * int
-    | IsNaN of int * int
-    | IsNegative of int * int
-    | IsPositive of int * int
-    | Ieee_format_to_fp of int * int
-    | To_fp of int * int * int * int
-    | Of_real of int * int
-    | Of_sbv of int * int * int
-    | Of_ubv of int * int * int
-    | To_ubv of int * int * int
-    | To_sbv of int * int * int
-    | To_real of int * int
+    | Plus_infinity of { e : int; s : int; }
+    | Minus_infinity of { e : int; s : int; }
+    | Plus_zero of { e : int; s : int; }
+    | Minus_zero of { e : int; s : int; }
+    | NaN of { e : int; s : int; }
+    | Abs of { e : int; s : int; }
+    | Neg of { e : int; s : int; }
+    | Add of { e : int; s : int; }
+    | Sub of { e : int; s : int; }
+    | Mul of { e : int; s : int; }
+    | Div of { e : int; s : int; }
+    | Fma of { e : int; s : int; }
+    | Sqrt of { e : int; s : int; }
+    | Rem of { e : int; s : int; }
+    | RoundToIntegral  of { e : int; s : int; }
+    | Min of { e : int; s : int; }
+    | Max of { e : int; s : int; }
+    | Leq of { e : int; s : int; }
+    | Lt of { e : int; s : int; }
+    | Geq of { e : int; s : int; }
+    | Gt of { e : int; s : int; }
+    | Eq of { e : int; s : int; }
+    | IsNormal of { e : int; s : int; }
+    | IsSubnormal of { e : int; s : int; }
+    | IsZero of { e : int; s : int; }
+    | IsInfinite of { e : int; s : int; }
+    | IsNaN of { e : int; s : int; }
+    | IsNegative of { e : int; s : int; }
+    | IsPositive of { e : int; s : int; }
+    | Ieee_format_to_fp of { e : int; s : int; }
+    | To_fp of { e1 : int; s1 : int; e2 : int; s2 : int; }
+    | Of_real of { e : int; s : int; }
+    | Of_sbv of { m : int; e : int; s : int; }
+    | Of_ubv of { m : int; e : int; s : int; }
+    | To_ubv of { m : int; e : int; s : int; }
+    | To_sbv of { m : int; e : int; s : int; }
+    | To_real of { e : int; s : int; }
 end
 
 type 'a t += Float of 'a Float.t

--- a/src/standard/builtin.ml
+++ b/src/standard/builtin.ml
@@ -17,9 +17,11 @@ type _ t += Base
 type _ t +=
   | Wildcard : { ty : 'ty option ref; } -> < ty : 'ty ; .. > t
 
-type _ t += Kind | Type | Prop
+type _ t += Kind | Type
 
-type _ t += | Unit | Univ
+type _ t += Unit | Univ
+
+type _ t += Equal | Distinct
 
 type _ t += Coercion
 
@@ -28,207 +30,258 @@ type _ t +=
   | Multi_trigger
   | Semantic_trigger
 
+type _ t += Pi | Sigma
+
+
 (* Boolean builtins *)
 (* ************************************************************************* *)
 
-type _ t +=
-  | True | False
-  | Equal | Distinct
-  | Neg | And | Or
-  | Nand | Nor | Xor
-  | Imply | Implied | Equiv
+module Prop = struct
+  type _ t =
+    | T (* Alias Prop *)
+    | True | False
+    | Neg | And | Or
+    | Nand | Nor | Xor
+    | Imply | Implied | Equiv
+    | Ite
+end
 
-type _ t += Ite
+type 'a t += Prop of 'a Prop.t
 
-type _ t += Pi | Sigma
 
 (* Algebraic datatype builtins *)
 (* ************************************************************************* *)
 
-type _ t +=
-  | Tester :
-      { adt: 'ty_cst; case: int; cstr : 'term_cst; } ->
-      < ty_cst : 'ty_cst ; term_cst : 'term_cst; .. > t
-  | Constructor :
-      { adt : 'ty_cst; case : int; } ->
-      < ty_cst : 'ty_cst ; .. > t
-  | Destructor :
-      { adt : 'ty_cst; case : int; cstr : 'term_cst; field: int; } ->
-      < ty_cst : 'ty_cst ; term_cst : 'term_cst; .. > t
+module Adt = struct
+  type _ t =
+    | Tester :
+        { adt: 'ty_cst; case: int; cstr : 'term_cst; } ->
+        < ty_cst : 'ty_cst ; term_cst : 'term_cst; .. > t
+    | Constructor :
+        { adt : 'ty_cst; case : int; } ->
+        < ty_cst : 'ty_cst ; .. > t
+    | Destructor :
+        { adt : 'ty_cst; case : int; cstr : 'term_cst; field: int; } ->
+        < ty_cst : 'ty_cst ; term_cst : 'term_cst; .. > t
+end
+
+type 'a t += Adt of 'a Adt.t
 
 
 (* HO encoding into FO using Maps *)
 (* ************************************************************************* *)
 
-type _ t +=
-  | Map
-  | Map_app
+module Map = struct
+  type _ t =
+    | T
+    | App
+end
+
+type 'a t += Map of 'a Map.t
 
 
 (* Arithmetic builtins *)
 (* ************************************************************************* *)
 
-type rat_real = [ `Rat | `Real ]
-type int_rat_real = [ `Int | `Rat | `Real ]
+module Arith = struct
+  type int_real = [ `Int | `Real ]
+  type rat_real = [ `Rat | `Real ]
+  type int_rat_real = [ `Int | `Rat | `Real ]
+  type _ t =
+    | Int | Integer of string
+    | Rat | Rational of string
+    | Real | Decimal of string
+    | Lt of int_rat_real | Leq of int_rat_real
+    | Gt of int_rat_real | Geq of int_rat_real
+    | Minus of int_rat_real
+    | Add of int_rat_real | Sub of int_rat_real
+    | Mul of int_rat_real | Pow of int_real
+    | Div of rat_real
+    | Div_e of int_rat_real | Modulo_e of int_rat_real
+    | Div_t of int_rat_real | Modulo_t of int_rat_real
+    | Div_f of int_rat_real | Modulo_f of int_rat_real
+    | Abs | Divisible
+    | Is_int of int_rat_real | Is_rat of int_rat_real
+    | Floor of int_rat_real | Floor_to_int of rat_real
+    | Ceiling of int_rat_real | Truncate of int_rat_real | Round of int_rat_real
+end
 
-type _ t +=
-  | Int | Integer of string
-  | Rat | Rational of string
-  | Real | Decimal of string
-  | Lt of int_rat_real | Leq of int_rat_real
-  | Gt of int_rat_real | Geq of int_rat_real
-  | Minus of int_rat_real
-  | Add of int_rat_real | Sub of int_rat_real
-  | Mul of int_rat_real | Pow of int_rat_real
-  | Div of rat_real
-  | Div_e of int_rat_real | Modulo_e of int_rat_real
-  | Div_t of int_rat_real | Modulo_t of int_rat_real
-  | Div_f of int_rat_real | Modulo_f of int_rat_real
-  | Abs | Divisible
-  | Is_int of int_rat_real | Is_rat of int_rat_real
-  | Floor of int_rat_real | Floor_to_int of rat_real
-  | Ceiling of int_rat_real | Truncate of int_rat_real | Round of int_rat_real
+type 'a t += Arith of 'a Arith.t
 
-(* arrays *)
-type _ t +=
-  | Array | Const | Store | Select
+
+(* Array builtins *)
+(* ************************************************************************* *)
+
+module Array = struct
+  type _ t =
+    | T | Const | Store | Select
+end
+
+type 'a t += Array of 'a Array.t
+
 
 (* Bitvectors *)
-type _ t +=
-  | Bitv of int
-  | Bitvec of string
-  | Bitv_to_int of { n : int; signed : bool; }
-  | Bitv_of_int of { n : int; }
-  | Bitv_concat of { n : int; m : int }
-  | Bitv_extract of { n : int; i : int; j : int }
-  | Bitv_repeat of { n : int; k : int }
-  | Bitv_zero_extend of { n : int; k : int }
-  | Bitv_sign_extend of { n : int; k : int }
-  | Bitv_rotate_right of { n : int; i : int }
-  | Bitv_rotate_left of { n : int; i : int }
-  | Bitv_not of int
-  | Bitv_and of int
-  | Bitv_or of int
-  | Bitv_nand of int
-  | Bitv_nor of int
-  | Bitv_xor of int
-  | Bitv_xnor of int
-  | Bitv_comp of int
-  | Bitv_neg of int
-  | Bitv_add of int
-  | Bitv_sub of int
-  | Bitv_mul of int
-  | Bitv_udiv of int
-  | Bitv_urem of int
-  | Bitv_sdiv of int
-  | Bitv_srem of int
-  | Bitv_smod of int
-  | Bitv_shl of int
-  | Bitv_lshr of int
-  | Bitv_ashr of int
-  | Bitv_ult of int
-  | Bitv_ule of int
-  | Bitv_ugt of int
-  | Bitv_uge of int
-  | Bitv_slt of int
-  | Bitv_sle of int
-  | Bitv_sgt of int
-  | Bitv_sge of int
-  | Bitv_overflow_neg of { n : int; }
-  | Bitv_overflow_add of { n : int; signed : bool; }
-  | Bitv_overflow_sub of { n : int; signed : bool; }
-  | Bitv_overflow_mul of { n : int; signed : bool; }
-  | Bitv_overflow_div of { n : int; }
+(* ************************************************************************* *)
+
+module Bitv = struct
+  type _ t =
+    | T of int
+    | Binary_lit of string
+    | To_int of { n : int; signed : bool; }
+    | Of_int of { n : int; }
+    | Concat of { n : int; m : int }
+    | Extract of { n : int; i : int; j : int }
+    | Repeat of { n : int; k : int }
+    | Zero_extend of { n : int; k : int }
+    | Sign_extend of { n : int; k : int }
+    | Rotate_right of { n : int; i : int }
+    | Rotate_left of { n : int; i : int }
+    | Not of int
+    | And of int
+    | Or of int
+    | Nand of int
+    | Nor of int
+    | Xor of int
+    | Xnor of int
+    | Comp of int
+    | Neg of int
+    | Add of int
+    | Sub of int
+    | Mul of int
+    | Udiv of int
+    | Urem of int
+    | Sdiv of int
+    | Srem of int
+    | Smod of int
+    | Shl of int
+    | Lshr of int
+    | Ashr of int
+    | Ult of int
+    | Ule of int
+    | Ugt of int
+    | Uge of int
+    | Slt of int
+    | Sle of int
+    | Sgt of int
+    | Sge of int
+    | Overflow_neg of { n : int; }
+    | Overflow_add of { n : int; signed : bool; }
+    | Overflow_sub of { n : int; signed : bool; }
+    | Overflow_mul of { n : int; signed : bool; }
+    | Overflow_div of { n : int; }
+end
+
+type 'a t += Bitv of 'a Bitv.t
+
 
 (* Floats *)
-type _ t +=
-  | Float of int * int
-  | RoundingMode
-  | Fp of int * int
-  | RoundNearestTiesToEven
-  | RoundNearestTiesToAway
-  | RoundTowardPositive
-  | RoundTowardNegative
-  | RoundTowardZero
-  | Plus_infinity of int * int
-  | Minus_infinity of int * int
-  | Plus_zero of int * int
-  | Minus_zero of int * int
-  | NaN of int * int
-  | Fp_abs of int * int
-  | Fp_neg of int * int
-  | Fp_add of int * int
-  | Fp_sub of int * int
-  | Fp_mul of int * int
-  | Fp_div of int * int
-  | Fp_fma of int * int
-  | Fp_sqrt of int * int
-  | Fp_rem of int * int
-  | Fp_roundToIntegral  of int * int
-  | Fp_min of int * int
-  | Fp_max of int * int
-  | Fp_leq of int * int
-  | Fp_lt of int * int
-  | Fp_geq of int * int
-  | Fp_gt of int * int
-  | Fp_eq of int * int
-  | Fp_isNormal of int * int
-  | Fp_isSubnormal of int * int
-  | Fp_isZero of int * int
-  | Fp_isInfinite of int * int
-  | Fp_isNaN of int * int
-  | Fp_isNegative of int * int
-  | Fp_isPositive of int * int
-  | Ieee_format_to_fp of int * int
-  | Fp_to_fp of int * int * int * int
-  | Real_to_fp of int * int
-  | Sbv_to_fp of int * int * int
-  | Ubv_to_fp of int * int * int
-  | To_ubv of int * int * int
-  | To_sbv of int * int * int
-  | To_real of int * int
+(* ************************************************************************* *)
+
+module Float = struct
+  type _ t =
+    | T of int * int
+    | RoundingMode
+    | Fp of int * int
+    | RoundNearestTiesToEven
+    | RoundNearestTiesToAway
+    | RoundTowardPositive
+    | RoundTowardNegative
+    | RoundTowardZero
+    | Plus_infinity of int * int
+    | Minus_infinity of int * int
+    | Plus_zero of int * int
+    | Minus_zero of int * int
+    | NaN of int * int
+    | Abs of int * int
+    | Neg of int * int
+    | Add of int * int
+    | Sub of int * int
+    | Mul of int * int
+    | Div of int * int
+    | Fma of int * int
+    | Sqrt of int * int
+    | Rem of int * int
+    | RoundToIntegral  of int * int
+    | Min of int * int
+    | Max of int * int
+    | Leq of int * int
+    | Lt of int * int
+    | Geq of int * int
+    | Gt of int * int
+    | Eq of int * int
+    | IsNormal of int * int
+    | IsSubnormal of int * int
+    | IsZero of int * int
+    | IsInfinite of int * int
+    | IsNaN of int * int
+    | IsNegative of int * int
+    | IsPositive of int * int
+    | Ieee_format_to_fp of int * int
+    | To_fp of int * int * int * int
+    | Of_real of int * int
+    | Of_sbv of int * int * int
+    | Of_ubv of int * int * int
+    | To_ubv of int * int * int
+    | To_sbv of int * int * int
+    | To_real of int * int
+end
+
+type 'a t += Float of 'a Float.t
+
 
 (* Strings *)
-type _ t +=
-  | String
-  | Str of string
-  | Str_length
-  | Str_at
-  | Str_to_code
-  | Str_of_code
-  | Str_is_digit
-  | Str_to_int
-  | Str_of_int
-  | Str_concat
-  | Str_sub
-  | Str_index_of
-  | Str_replace
-  | Str_replace_all
-  | Str_replace_re
-  | Str_replace_re_all
-  | Str_is_prefix
-  | Str_is_suffix
-  | Str_contains
-  | Str_lexicographic_strict
-  | Str_lexicographic_large
-  | Str_in_re
+(* ************************************************************************* *)
 
-(* String Regular languages *)
-type _ t +=
-  | String_RegLan
-  | Re_empty
-  | Re_all
-  | Re_allchar
-  | Re_of_string
-  | Re_range
-  | Re_concat
-  | Re_union
-  | Re_inter
-  | Re_star
-  | Re_cross
-  | Re_complement
-  | Re_diff
-  | Re_option
-  | Re_power of int
-  | Re_loop of int * int
+module Str = struct
+
+  type _ t =
+    | T
+    | Raw of string
+    | Length
+    | At
+    | To_code
+    | Of_code
+    | Is_digit
+    | To_int
+    | Of_int
+    | Concat
+    | Sub
+    | Index_of
+    | Replace
+    | Replace_all
+    | Replace_re
+    | Replace_re_all
+    | Is_prefix
+    | Is_suffix
+    | Contains
+    | Lexicographic_strict
+    | Lexicographic_large
+    | In_re
+
+  (* String Regular languages *)
+  module RegLan = struct
+    type _ t =
+      | T
+      | Empty
+      | All
+      | Allchar
+      | Of_string
+      | Range
+      | Concat
+      | Union
+      | Inter
+      | Star
+      | Cross
+      | Complement
+      | Diff
+      | Option
+      | Power of int
+      | Loop of int * int
+  end
+
+end
+
+type 'a t +=
+  | Str of 'a Str.t
+  | Regexp of 'a Str.RegLan.t
 

--- a/src/standard/builtin.mli
+++ b/src/standard/builtin.mli
@@ -382,156 +382,156 @@ type 'a t += Array of 'a Array.t
 
 module Bitv : sig
   type _ t =
-    | T of int
-    (** [Bitv.T n: ttype]: type constructor for bitvectors of length [n].
+    | T of { n: int; }
+    (** [Bitv.T{n}: ttype]: type constructor for bitvectors of length [n].
         Ensures that [n > 0]. *)
     | Binary_lit of string
     (** [Lit s: Bitv.T]: bitvector litteral. The string [s] should
         be a binary representation of bitvectors using characters
         ['0'], and ['1'] (lsb last) *)
     | To_int of { n : int; signed : bool; }
-    (** [To_int(n,signed): Bitv.T(n) -> Int]:
+    (** [To_int{n; signed; }: Bitv.T{n} -> Int]:
         conversion from bitvectors to signed integers. *)
     | Of_int of { n : int; }
-    (** [Of_int(n): Int -> Bitv.T(n)]:
+    (** [Of_int{n}: Int -> Bitv.T{n}]:
         conversion fromm (signed) integers to bitvectors. *)
     | Concat of { n : int; m : int }
-    (** [Concat(n,m): Bitv.T(n) -> Bitv.T(m) -> Bitv.T(n+m)]:
+    (** [Concat{n;m}: Bitv.T{n} -> Bitv.T{m} -> Bitv.T{n+m}]:
         concatenation operator on bitvectors. *)
     | Extract of { n : int; i : int; j : int }
-    (** [Extract(n, i, j): Bitv.T(n) -> Bitv.T(i - j + 1)]:
+    (** [Extract{n; i; j}: Bitv.T{n} -> Bitv.T{i - j + 1}]:
         bitvector extraction, from index [j] up to [i] (both included).
         Ensures that [0 <= j <= i < n]. *)
     | Repeat of { n : int; k : int }
-    (** [Repeat(n,k): Bitv.T(n) -> Bitv.T(n*k)]:
+    (** [Repeat{n;k}: Bitv.T{n} -> Bitv.T{n*k}]:
         bitvector repeatition. *)
     | Zero_extend of { n : int; k : int }
-    (** [Zero_extend(n,k): Bitv.T(n) -> Bitv.T(n + k)]:
+    (** [Zero_extend{n;k}: Bitv.T{n} -> Bitv.T{n + k}]:
         zero extension for bitvectors (produces a representation of the
         same unsigned integer). *)
     | Sign_extend of { n : int; k : int }
-    (** [Sign_extend(n,k): Bitv.T(n) -> Bitv.T(n + k)]:
+    (** [Sign_extend{n;k}: Bitv.T{n} -> Bitv.T{n + k}]:
         sign extension for bitvectors ((produces a representation of the
         same signed integer). *)
     | Rotate_right of { n : int; i : int }
-    (** [Rotate_right(n,i): Bitv.T(n) -> Bitv.T(n)]:
+    (** [Rotate_right{n;i}: Bitv.T{n} -> Bitv.T{n}]:
         logical rotate right for bitvectors by [i]. *)
     | Rotate_left of { n : int; i : int }
-    (** [Rotate_left(n,i): Bitv.T(n) -> Bitv.T(n)]:
+    (** [Rotate_left{n;i}: Bitv.T{n} -> Bitv.T{n}]:
         logical rotate left for bitvectors by [i]. *)
-    | Not of int
-    (** [not(n): Bitv.T(n) -> Bitv.T(n)]:
+    | Not of { n : int; }
+    (** [Not{n}: Bitv.T{n} -> Bitv.T{n}]:
         bitwise negation for bitvectors. *)
-    | And of int
-    (** [and(n): Bitv.T(n) -> Bitv.T(n) -> Bitv.T(n)]:
+    | And of { n : int; }
+    (** [And{n}: Bitv.T{n} -> Bitv.T{n} -> Bitv.T{n}]:
         bitwise conjunction for bitvectors. *)
-    | Or of int
-    (** [bitv_or(n): Bitv.T(n) -> Bitv.T(n) -> Bitv.T(n)]:
+    | Or of { n : int; }
+    (** [Or{n}: Bitv.T{n} -> Bitv.T{n} -> Bitv.T{n}]:
         bitwise disjunction for bitvectors. *)
-    | Nand of int
-    (** [nand(n): Bitv.T(n) -> Bitv.T(n) -> Bitv.T(n)]:
+    | Nand of { n : int; }
+    (** [Nand{n}: Bitv.T{n} -> Bitv.T{n} -> Bitv.T{n}]:
         bitwise negated conjunction for bitvectors.
         [Nand s t] abbreviates [Not (And s t))]. *)
-    | Nor of int
-    (** [Nor(n): Bitv.T(n) -> Bitv.T(n) -> Bitv.T(n)]:
+    | Nor of { n : int; }
+    (** [Nor{n}: Bitv.T{n} -> Bitv.T{n} -> Bitv.T{n}]:
         bitwise negated disjunction for bitvectors.
         [Nor s t] abbreviates [Not (Or s t))]. *)
-    | Xor of int
-    (** [Xor(n): Bitv.T(n) -> Bitv.T(n) -> Bitv.T(n)]:
+    | Xor of { n: int; }
+    (** [Xor{n}: Bitv.T{n} -> Bitv.T{n} -> Bitv.T{n}]:
         bitwise exclusive disjunction for bitvectors.
         [Xor s t] abbreviates
         [Or (And s (Not t)) (And (Not s) t) ]. *)
-    | Xnor of int
-    (** [Xnor(n): Bitv.T(n) -> Bitv.T(n) -> Bitv.T(n)]:
+    | Xnor of { n : int; }
+    (** [Xnor{n}: Bitv.T{n} -> Bitv.T{n} -> Bitv.T{n}]:
         bitwise negated exclusive disjunction for bitvectors.
         [Xnor s t] abbreviates
         [Or (And s t) (And (Not s) (Not t))]. *)
-    | Comp of int
-    (** [Comp(n): Bitv.T(n) -> Bitv.T(n) -> Bitv.T(1)]:
+    | Comp of { n : int; }
+    (** [Comp{n}: Bitv.T{n} -> Bitv.T{n} -> Bitv.T{1}]:
         Returns the constant bitvector ["1"] is all bits are equal,
         and the bitvector ["0"] if not. *)
-    | Neg of int
-    (** [Neg(n): Bitv.T(n) -> Bitv.T(n)]:
+    | Neg of { n : int; }
+    (** [Neg{n}: Bitv.T{n} -> Bitv.T{n}]:
         2's complement unary minus. *)
-    | Add of int
-    (** [Add(n): Bitv.T(n) -> Bitv.T(n) -> Bitv.T(n)]:
+    | Add of { n : int; }
+    (** [Add{n}: Bitv.T{n} -> Bitv.T{n} -> Bitv.T{n}]:
         addition modulo 2^n. *)
-    | Sub of int
-    (** [Sub(n): Bitv.T(n) -> Bitv.T(n) -> Bitv.T(n)]:
+    | Sub of { n : int; }
+    (** [Sub{n}: Bitv.T{n} -> Bitv.T{n} -> Bitv.T{n}]:
         2's complement subtraction modulo 2^n. *)
-    | Mul of int
-    (** [Mul(n): Bitv.T(n) -> Bitv.T(n) -> Bitv.T(n)]:
+    | Mul of { n : int; }
+    (** [Mul{n}: Bitv.T{n} -> Bitv.T{n} -> Bitv.T{n}]:
         multiplication modulo 2^n. *)
-    | Udiv of int
-    (** [Udiv(n): Bitv.T(n) -> Bitv.T(n) -> Bitv.T(n)]:
+    | Udiv of { n : int; }
+    (** [Udiv{n}: Bitv.T{n} -> Bitv.T{n} -> Bitv.T{n}]:
         unsigned division, truncating towards 0. *)
-    | Urem of int
-    (** [Urem(n): Bitv.T(n) -> Bitv.T(n) -> Bitv.T(n)]:
+    | Urem of { n : int; }
+    (** [Urem{n}: Bitv.T{n} -> Bitv.T{n} -> Bitv.T{n}]:
         unsigned remainder from truncating division. *)
-    | Sdiv of int
-    (** [Sdiv(n): Bitv.T(n) -> Bitv.T(n) -> Bitv.T(n)]:
+    | Sdiv of { n : int; }
+    (** [Sdiv{n}: Bitv.T{n} -> Bitv.T{n} -> Bitv.T{n}]:
         2's complement signed division. *)
-    | Srem of int
-    (** [Srem(n): Bitv.T(n) -> Bitv.T(n) -> Bitv.T(n)]:
+    | Srem of { n : int; }
+    (** [Srem{n}: Bitv.T{n} -> Bitv.T{n} -> Bitv.T{n}]:
         2's complement signed remainder (sign follows dividend). *)
-    | Smod of int
-    (** [Smod(n): Bitv.T(n) -> Bitv.T(n) -> Bitv.T(n)]:
+    | Smod of { n : int; }
+    (** [Smod{n}: Bitv.T{n} -> Bitv.T{n} -> Bitv.T{n}]:
         2's complement signed remainder (sign follows divisor). *)
-    | Shl of int
-    (** [Shl(n): Bitv.T(n) -> Bitv.T(n) -> Bitv.T(n)]:
+    | Shl of { n : int; }
+    (** [Shl{n}: Bitv.T{n} -> Bitv.T{n} -> Bitv.T{n}]:
         shift left (equivalent to multiplication by 2^x where x
         is the value of the second argument). *)
-    | Lshr of int
-    (** [Lshr(n): Bitv.T(n) -> Bitv.T(n) -> Bitv.T(n)]:
+    | Lshr of { n : int; }
+    (** [Lshr{n}: Bitv.T{n} -> Bitv.T{n} -> Bitv.T{n}]:
         logical shift right (equivalent to unsigned division by 2^x,
         where x is the value of the second argument). *)
-    | Ashr of int
-    (** [Ashr(n): Bitv.T(n) -> Bitv.T(n) -> Bitv.T(n)]:
+    | Ashr of { n : int; }
+    (** [Ashr{n}: Bitv.T{n} -> Bitv.T{n} -> Bitv.T{n}]:
         Arithmetic shift right, like logical shift right except that
         the most significant bits of the result always copy the most
         significant bit of the first argument. *)
-    | Ult of int
-    (** [Ult(n): Bitv.T(n) -> Bitv.T(n) -> Prop.T]:
+    | Ult of { n : int; }
+    (** [Ult{n}: Bitv.T{n} -> Bitv.T{n} -> Prop.T]:
         binary predicate for unsigned less-than. *)
-    | Ule of int
-    (** [ule(n): Bitv.T(n) -> Bitv.T(n) -> Prop.T]:
+    | Ule of { n : int; }
+    (** [Ule{n}: Bitv.T{n} -> Bitv.T{n} -> Prop.T]:
         binary predicate for unsigned less than or equal. *)
-    | Ugt of int
-    (** [Ugt(n): Bitv.T(n) -> Bitv.T(n) -> Prop.T]:
+    | Ugt of { n : int; }
+    (** [Ugt{n}: Bitv.T{n} -> Bitv.T{n} -> Prop.T]:
         binary predicate for unsigned greater-than. *)
-    | Uge of int
-    (** [Uge(n): Bitv.T(n) -> Bitv.T(n) -> Prop.T]:
+    | Uge of { n : int; }
+    (** [Uge{n}: Bitv.T{n} -> Bitv.T{n} -> Prop.T]:
         binary predicate for unsigned greater than or equal. *)
-    | Slt of int
-    (** [Slt(n): Bitv.T(n) -> Bitv.T(n) -> Prop.T]:
+    | Slt of { n : int; }
+    (** [Slt{n}: Bitv.T{n} -> Bitv.T{n} -> Prop.T]:
         binary predicate for signed less-than. *)
-    | Sle of int
-    (** [Sle(n): Bitv.T(n) -> Bitv.T(n) -> Prop.T]:
+    | Sle of { n : int; }
+    (** [Sle{n}: Bitv.T{n} -> Bitv.T{n} -> Prop.T]:
         binary predicate for signed less than or equal. *)
-    | Sgt of int
-    (** [Sgt(n): Bitv.T(n) -> Bitv.T(n) -> Prop.T]:
+    | Sgt of { n: int; }
+    (** [Sgt{n}: Bitv.T{n} -> Bitv.T{n} -> Prop.T]:
         binary predicate for signed greater-than. *)
-    | Sge of int
-    (** [Sge(n): Bitv.T(n) -> Bitv.T(n) -> Prop.T]:
+    | Sge of { n : int; }
+    (** [Sge{n}: Bitv.T{n} -> Bitv.T{n} -> Prop.T]:
         binary predicate for signed greater than or equal. *)
     | Overflow_neg of { n : int; }
-    (** [Overflow_neg(n) : Bitv.T(n) -> Prop.T]:
+    (** [Overflow_neg{n} : Bitv.T{n} -> Prop.T]:
         unary overflow predicate for signed unary minus
         (i.e. returns [true] if the negation would overflow) *)
     | Overflow_add of { n : int; signed : bool; }
-    (** [Overflow_add(n,signed) : Bitv.T(n) -> Bitv.T(n) -> Prop.T]:
+    (** [Overflow_add{n;signed} : Bitv.T{n} -> Bitv.T{n} -> Prop.T]:
         binary overflow predicate for signed/unsigned addition
         (i.e. returns [true] if the operation would overflow) *)
     | Overflow_sub of { n : int; signed : bool; }
-    (** [Overflow_sub(n,signed): Bitv.T(n) -> Bitv.T(n) -> Prop.T
+    (** [Overflow_sub{n;signed}: Bitv.T{n} -> Bitv.T{n} -> Prop.T
         binary overflow predicate for signed/unsigned subtraction
         (i.e. returns [true] if the operation would overflow) *)
     | Overflow_mul of { n : int; signed : bool; }
-    (** [Overflow_mul(n,signed): Bitv.T(n) -> Bitv.T(n) -> Prop.T
+    (** [Overflow_mul{n;signed}: Bitv.T{n} -> Bitv.T{n} -> Prop.T
         binary overflow predicate for signed/unsigned multiplication
         (i.e. returns [true] if the operation would overflow) *)
     | Overflow_div of { n : int; }
-    (** [Overflow_mul(n,signed): Bitv.T(n) -> Bitv.T(n) -> Prop.T
+    (** [Overflow_div{n}: Bitv.T{n} -> Bitv.T{n} -> Prop.T
         binary overflow predicate for signed division
         (i.e. returns [true] if the operation would overflow) *)
 end
@@ -545,14 +545,14 @@ type 'a t += Bitv of 'a Bitv.t
 
 module Float : sig
   type _ t =
-    | T of int * int
+    | T of { e : int; s : int; }
     (** [Float(e,s): ttype]: type constructor for floating point of exponent of
         size [e] and significand of size [s] (hidden bit included). Those size are
         greater than 1 *)
     | RoundingMode
     (** [RoundingMode: ttype]: type for enumerated type of rounding modes. *)
-    | Fp of int * int
-    (** [Fp(e, s): Bitv.T(1) -> Bitv.T(e) -> Bitv.T(s-1) -> Fp(e,s)]: bitvector literal.
+    | Fp of { e : int; s : int; }
+    (** [Fp(e, s): Bitv.T{1} -> Bitv.T{e} -> Bitv.T{s-1} -> Fp(e,s)]: bitvector literal.
         The IEEE-format is used for the conversion [sb^se^ss].
         All the NaN are converted to the same value. *)
     | RoundNearestTiesToEven
@@ -565,81 +565,81 @@ module Float : sig
     (** [RoundTowardNegative : RoundingMode *)
     | RoundTowardZero
     (** [RoundTowardZero : RoundingMode *)
-    | Plus_infinity of int * int
-    (** [Plus_infinity(s,e) : Fp(s,e)] *)
-    | Minus_infinity of int * int
-    (** [Minus_infinity(s,e) : Fp(s,e)] *)
-    | Plus_zero of int * int
-    (** [Plus_zero(s,e) : Fp(s,e)] *)
-    | Minus_zero of int * int
-    (** [Minus_zero(s,e) : Fp(s,e)] *)
-    | NaN of int * int
-    (** [NaN(s,e) : Fp(s,e)] *)
-    | Abs  of int * int
-    (** [Fp_abs(s,e): Fp(s,e) -> Fp(s,e)]: absolute value *)
-    | Neg  of int * int
-    (** [Fp_neg(s,e): Fp(s,e) -> Fp(s,e)]: negation *)
-    | Add  of int * int
-    (** [Fp_add(s,e): RoundingMode -> Fp(s,e) -> Fp(s,e) -> Fp(s,e)]: addition *)
-    | Sub  of int * int
-    (** [Fp_sub(s,e): RoundingMode -> Fp(s,e) -> Fp(s,e) -> Fp(s,e)]: subtraction *)
-    | Mul  of int * int
-    (** [Fp_mul(s,e): RoundingMode -> Fp(s,e) -> Fp(s,e) -> Fp(s,e)]: multiplication *)
-    | Div  of int * int
-    (** [Fp_div(s,e): RoundingMode -> Fp(s,e) -> Fp(s,e) -> Fp(s,e)]: division *)
-    | Fma  of int * int
-    (** [Fp_fma(s,e): RoundingMode -> Fp(s,e) -> Fp(s,e)]: fuse multiply add *)
-    | Sqrt  of int * int
-    (** [Fp_sqrt(s,e): RoundingMode -> Fp(s,e) -> Fp(s,e)]: square root *)
-    | Rem  of int * int
-    (** [Fp_rem(s,e): Fp(s,e) -> Fp(s,e) -> Fp(s,e)]: remainder *)
-    | RoundToIntegral  of int * int
-    (** [Fp_roundToIntegral(s,e): RoundingMode -> Fp(s,e) -> Fp(s,e)]: round to integral *)
-    | Min  of int * int
-    (** [Fp_min(s,e): Fp(s,e) -> Fp(s,e) -> Fp(s,e)]: minimum *)
-    | Max  of int * int
-    (** [Fp_max(s,e): Fp(s,e) -> Fp(s,e) -> Fp(s,e)]: maximum *)
-    | Leq  of int * int
-    (** [Fp_leq(s,e): Fp(s,e) -> Fp(s,e) -> Prop.T]: IEEE less or equal *)
-    | Lt  of int * int
-    (** [Fp_lt(s,e): Fp(s,e) -> Fp(s,e) -> Prop.T]: IEEE less than *)
-    | Geq  of int * int
-    (** [Fp_geq(s,e): Fp(s,e) -> Fp(s,e) -> Prop.T]: IEEE greater or equal *)
-    | Gt  of int * int
-    (** [Fp_gt(s,e): Fp(s,e) -> Fp(s,e) -> Prop.T]: IEEE greater than *)
-    | Eq  of int * int
-    (** [Fp_eq(s,e): Fp(s,e) -> Fp(s,e) -> Prop.T]: IEEE equality *)
-    | IsNormal  of int * int
-    (** [Fp_isNormal(s,e): Fp(s,e) -> Prop.T]: test if it is a normal floating point *)
-    | IsSubnormal  of int * int
-    (** [Fp_isSubnormal(s,e): Fp(s,e) -> Prop.T]: test if it is a subnormal floating point *)
-    | IsZero  of int * int
-    (** [Fp_isZero(s,e): Fp(s,e) -> Prop.T]: test if it is a zero *)
-    | IsInfinite  of int * int
-    (** [Fp_isInfinite(s,e): Fp(s,e) -> Prop.T]: test if it is an infinite *)
-    | IsNaN  of int * int
-    (** [Fp_isNaN(s,e): Fp(s,e) -> Prop.T]: test if it is Not a Number *)
-    | IsNegative  of int * int
-    (** [Fp_isNegative(s,e): Fp(s,e) -> Prop.T]: test if it is negative *)
-    | IsPositive  of int * int
-    (** [Fp_isPositive(s,e): Fp(s,e) -> Prop.T]: test if it is positive *)
-    | Ieee_format_to_fp of int * int
-    (** [Ieee_format_to_fp(s,e): Bv(s+e) -> Fp(s,e)]: Convert from IEEE interchange format *)
-    | To_fp of int * int * int * int
-    (** [Fp_to_fp(s1,e1,s2,e2): RoundingMode -> Fp(s1,e1) -> Fp(s2,e2)]:
+    | Plus_infinity of { e: int; s : int; }
+    (** [Plus_infinity{e;s} : Fp{e;s}] *)
+    | Minus_infinity of { e : int; s : int; }
+    (** [Minus_infinity{e;s} : Fp{e;s}] *)
+    | Plus_zero of { e: int; s : int; }
+    (** [Plus_zero{e;s} : Fp{e;s}] *)
+    | Minus_zero of { e : int; s : int; }
+    (** [Minus_zero{e;s} : Fp{e;s}] *)
+    | NaN of { e : int; s : int; }
+    (** [NaN{e;s} : Fp{e;s}] *)
+    | Abs of { e : int; s : int; }
+    (** [abs{e;s}: Fp{e;s} -> Fp{e;s}]: absolute value *)
+    | Neg of { e : int; s : int; }
+    (** [neg{e;s}: Fp{e;s} -> Fp{e;s}]: negation *)
+    | Add of { e : int; s : int; }
+    (** [add{e;s}: RoundingMode -> Fp{e;s} -> Fp{e;s} -> Fp{e;s}]: addition *)
+    | Sub of { e : int; s : int; }
+    (** [Sub{e;s}: RoundingMode -> Fp{e;s} -> Fp{e;s} -> Fp{e;s}]: subtraction *)
+    | Mul of { e : int; s : int; }
+    (** [Mul{e;s}: RoundingMode -> Fp{e;s} -> Fp{e;s} -> Fp{e;s}]: multiplication *)
+    | Div of { e : int; s : int; }
+    (** [Div{e;s}: RoundingMode -> Fp{e;s} -> Fp{e;s} -> Fp{e;s}]: division *)
+    | Fma of { e : int; s : int; }
+    (** [Fma{e:s}: RoundingMode -> Fp{e;s} -> Fp{e;s}]: fuse multiply add *)
+    | Sqrt of { e : int; s : int; }
+    (** [Sqrt{e;s}: RoundingMode -> Fp{e;s} -> Fp{e;s}]: square root *)
+    | Rem of { e : int; s : int; }
+    (** [Rem{e;s}: Fp{e;s} -> Fp{e;s} -> Fp{e;s}]: remainder *)
+    | RoundToIntegral of { e : int; s : int; }
+    (** [RoundToIntegral{e;s}: RoundingMode -> Fp{e;s} -> Fp{e;s}]: round to integral *)
+    | Min of { e : int; s : int; }
+    (** [Min{e;s}: Fp{e;s} -> Fp{e;s} -> Fp{e;s}]: minimum *)
+    | Max of { e : int; s : int; }
+    (** [Max{e;s}: Fp{e;s} -> Fp{e;s} -> Fp{e;s}]: maximum *)
+    | Leq of { e : int; s : int; }
+    (** [Leq{e;s}: Fp{e;s} -> Fp{e;s} -> Prop.T]: IEEE less or equal *)
+    | Lt of { e: int; s : int; }
+    (** [Lt{e;s}: Fp{e;s} -> Fp{e;s} -> Prop.T]: IEEE less than *)
+    | Geq of { e: int; s : int; }
+    (** [Geq{e;s}: Fp{e;s} -> Fp{e;s} -> Prop.T]: IEEE greater or equal *)
+    | Gt of { e : int; s : int; }
+    (** [Gt{e;s}: Fp{e;s} -> Fp{e;s} -> Prop.T]: IEEE greater than *)
+    | Eq of { e : int; s : int; }
+    (** [Eq(s,e): Fp(s,e) -> Fp(s,e) -> Prop.T]: IEEE equality *)
+    | IsNormal of { e : int; s : int; }
+    (** [IsNormal{e;s}: Fp{e;s} -> Prop.T]: test if it is a normal floating point *)
+    | IsSubnormal of { e: int; s : int; }
+    (** [IsSubnormal{e;s}: Fp{e;s} -> Prop.T]: test if it is a subnormal floating point *)
+    | IsZero of { e : int; s : int; }
+    (** [IsZero{e;s}: Fp{e;s} -> Prop.T]: test if it is a zero *)
+    | IsInfinite of { e : int; s : int; }
+    (** [IsInfinite{e;s}: Fp{e;s} -> Prop.T]: test if it is an infinite *)
+    | IsNaN of { e : int; s : int; }
+    (** [IsNaN{e;s}: Fp{e;s} -> Prop.T]: test if it is Not a Number *)
+    | IsNegative of { e : int; s : int; }
+    (** [IsNegative{e;s}: Fp{e;s} -> Prop.T]: test if it is negative *)
+    | IsPositive of { e : int; s : int; }
+    (** [IsPositive{e;s}: Fp{e;s} -> Prop.T]: test if it is positive *)
+    | Ieee_format_to_fp of { e : int; s : int; }
+    (** [Ieee_format_to_fp{e;s}: Bv{n=s+e} -> Fp{e;s}]: Convert from IEEE interchange format *)
+    | To_fp of { e1 :int; s1 : int; e2 : int; s2 : int; }
+    (** [To_fp{e1;s1;e2;s2}: RoundingMode -> Fp{e1;s2} -> Fp{e2;s2}]:
         Convert from another floating point format *)
-    | Of_real of int * int
-    (** [Real_to_fp(s,e): RoundingMode -> Real -> Fp(s,e)]: Convert from a real *)
-    | Of_sbv of int * int * int
-    (** [Sbv_to_fp(m,s,e): RoundingMode -> Bitv.T(m) -> Fp(s,e)]: Convert from a signed integer *)
-    | Of_ubv of int * int * int
-    (** [Ubv_to_fp(m,s,e): RoundingMode -> Bitv.T(m) -> Fp(s,e)]: Convert from a unsigned integer *)
-    | To_ubv of int * int * int
-    (** [To_ubv(s,e,m): RoundingMode -> Fp(s,e) -> Bitv.T(m)]: Convert to an unsigned integer *)
-    | To_sbv of int * int * int
-    (** [To_ubv(s,e,m): RoundingMode -> Fp(s,e) -> Bitv.T(m)]: Convert to an signed integer *)
-    | To_real of int * int
-    (** [To_real(s,e): Fp(s,e) -> Real]: Convert to real *)
+    | Of_real of { e : int; s : int; }
+    (** [Of_real{e;s}: RoundingMode -> Real -> Fp{e;s}]: Convert from a real *)
+    | Of_sbv of { m : int; e: int; s: int; }
+    (** [Of_sbv{m;e;s}: RoundingMode -> Bitv.T{n=m} -> Fp{e;s}]: Convert from a signed integer *)
+    | Of_ubv of { m : int; e : int; s : int; }
+    (** [Of_ubv{m;e;s}: RoundingMode -> Bitv.T{n=m} -> Fp{e;s}]: Convert from a unsigned integer *)
+    | To_ubv of { m : int; e : int; s : int; }
+    (** [To_ubv{m;e;s}: RoundingMode -> Fp{e;s} -> Bitv.T{n=m}]: Convert to an unsigned integer *)
+    | To_sbv of { m : int; e : int; s : int; }
+    (** [To_sbv{m;e;s}: RoundingMode -> Fp{e;s} -> Bitv.T{n=m}]: Convert to an signed integer *)
+    | To_real of { e : int; s : int; }
+    (** [To_real{e;s}: Fp{e;s} -> Real]: Convert to real *)
 end
 
 type 'a t += Float of 'a Float.t

--- a/src/standard/builtin.mli
+++ b/src/standard/builtin.mli
@@ -24,7 +24,7 @@
     - [int] is a constant of type [int]
     - [float -> int] is a unary function
     - ['a. 'a -> 'a] is a polymorphic unary function
-    - ['a. 'a -> ... -> Prop] describes a family of functions that take
+    - ['a. 'a -> ... -> Prop.T] describes a family of functions that take
       a type and then an arbitrary number of arguments of that type, and
       return a proposition (this is for instance the type of equality).
 
@@ -34,7 +34,7 @@
     integers, rationals, or reals. Note that arbitrary arity operators (well
     family of operators) can be also be seen as overloaded operators.
     Overloaded types (particularly for numbers) are written:
-    - [{a=(Int|Rational|Real)} a -> a -> Prop], where the notable difference
+    - [{a=(Int|Rational|Real)} a -> a -> Prop.T], where the notable difference
       with polymorphic functions is that functions of this type does not
       take a type argument.
 *)
@@ -68,9 +68,6 @@ type _ t +=
       It is an error to try and access the type of kind. *)
   | Type
   (** Builtin used to represent the type of types. *)
-  | Prop
-  (** [Prop: ttype]: the builtin type constant for the type of
-      propositions / booleans. *)
 
 type _ t +=
   | Unit
@@ -78,6 +75,12 @@ type _ t +=
   | Univ
   (** [Univ: ttype]: a builtin type constant used for languages
       with a default type for elements (such as tptp's `$i`). *)
+
+type _ t +=
+  | Equal
+  (** [Equal: 'a. 'a -> ... -> Prop.T]: equality beetween values. *)
+  | Distinct
+  (** [Distinct: 'a. 'a -> ... -> Prop.T]: pairwise dis-equality beetween arguments. *)
 
 type _ t +=
   | Coercion
@@ -95,12 +98,12 @@ type _ t +=
 
 type _ t +=
   | Multi_trigger
-  (** [Multi_trigger: 'a1 ... 'an. 'a1 -> ... -> 'an -> Prop]:
+  (** [Multi_trigger: 'a1 ... 'an. 'a1 -> ... -> 'an -> Prop.T]:
       Create a multi trigger: it takes an arbitrarily long list
       of terms of arbitrary types. *)
 
   | Maps_to
-  (** [Maps_to: 'term_var -> 'term -> Prop]:
+  (** [Maps_to: 'term_var -> 'term -> Prop.T]:
       Used in semantic triggers for floating point arithmetic.
       See [alt-ergo/src/preludes/fpa-theory-2017-01-04-16h00.ae].
 
@@ -108,657 +111,699 @@ type _ t +=
       allowed inside theories. *)
 
   | Semantic_trigger
-  (** [Semantic_trigger: Prop -> Prop]:
+  (** [Semantic_trigger: Prop.T -> Prop.T]:
       Denote that its argument is a semantic trigger
       (used only by Alt-ergo currently). *)
+
+type _ t +=
+  | Pi
+  (** [Pi: 'a. ('a -> Prop.T) -> Prop.T]: higher-order encoding of universal quantification. *)
+  | Sigma
+  (** [Sigma: 'a. ('a -> Prop.T) -> Prop.T]: higher-order encoding of existencial quantification. *)
+
 
 (** {2 Boolean Builtins} *)
 (*  ************************************************************************* *)
 
-type _ t +=
-  | True      (** [True: Prop]: the [true] proposition. *)
-  | False     (** [False: Prop]: the [false] proposition. *)
-  | Equal     (** [Equal: 'a. 'a -> ... -> Prop]: equality beetween values. *)
-  | Distinct  (** [Distinct: 'a. 'a -> ... -> Prop]: pairwise dis-equality beetween arguments. *)
-  | Neg       (** [Neg: Prop -> Prop]: propositional negation. *)
-  | And       (** [And: Prop -> ... -> Prop]: propositional conjunction. *)
-  | Or        (** [Or: Prop -> ... -> Prop]: propositional disjunction. *)
-  | Nand      (** [Nand: Prop -> Prop -> Prop]: propositional negated conjunction. *)
-  | Nor       (** [Nor: Prop -> Prop -> Prop]: propositional negated disjunction. *)
-  | Xor       (** [Xor: Prop -> Prop -> Prop]: ppropositional exclusive disjunction. *)
-  | Imply     (** [Imply: Prop -> Prop -> Prop]: propositional implication. *)
-  | Implied   (** [Implied: Prop -> Prop -> Prop]: reverse propositional implication. *)
-  | Equiv     (** [Equiv: Prop -> Prop -> Prop]: propositional Equivalence. *)
+module Prop : sig
+  type _ t =
+    | T         (** [Prop.T.T: ttype]: the builtin type constant for the type of propositions / booleans. *)
+    | True      (** [True: Prop.T]: the [true] proposition. *)
+    | False     (** [False: Prop.T]: the [false] proposition. *)
+    | Neg       (** [Neg: Prop.T -> Prop.T]: propositional negation. *)
+    | And       (** [And: Prop.T -> ... -> Prop.T]: propositional conjunction. *)
+    | Or        (** [Or: Prop.T -> ... -> Prop.T]: propositional disjunction. *)
+    | Nand      (** [Nand: Prop.T -> Prop.T -> Prop.T]: propositional negated conjunction. *)
+    | Nor       (** [Nor: Prop.T -> Prop.T -> Prop.T]: propositional negated disjunction. *)
+    | Xor       (** [Xor: Prop.T -> Prop.T -> Prop.T]: ppropositional exclusive disjunction. *)
+    | Imply     (** [Imply: Prop.T -> Prop.T -> Prop.T]: propositional implication. *)
+    | Implied   (** [Implied: Prop.T -> Prop.T -> Prop.T]: reverse propositional implication. *)
+    | Equiv     (** [Equiv: Prop.T -> Prop.T -> Prop.T]: propositional Equivalence. *)
+    | Ite       (** [Ite: 'a. Prop.T -> 'a -> 'a -> 'a]: branching operator. *)
+end
 
-type _ t +=
-  | Ite
-  (** [Ite: 'a. Prop -> 'a -> 'a -> 'a]: branching operator. *)
-
-type _ t +=
-  | Pi
-  (** [Pi: 'a. ('a -> Prop) -> Prop]: higher-order encoding of universal quantification. *)
-  | Sigma
-  (** [Sigma: 'a. ('a -> Prop) -> Prop]: higher-order encoding of existencial quantification. *)
+type 'a t += Prop of 'a Prop.t
+(** Boolean builtins. *)
 
 
 (** {2 Algebraic datatype Builtins} *)
 (*  ************************************************************************* *)
 
-type _ t +=
-  | Tester :
-      { adt: 'ty_cst; case: int; cstr : 'term_cst; } ->
-      < ty_cst : 'ty_cst ; term_cst : 'term_cst; .. > t
-  (** [Tester { adt; cstr; case; }] is the tester of the case-th constructor
-      of type [adt] which should be [cstr]. *)
-  | Constructor :
-      { adt : 'ty_cst; case : int; } ->
-      < ty_cst : 'ty_cst ; .. > t
-  (** [Constructor { adt; case}] is the case-th constructor of the algebraic
-      datatype defined by [adt]. *)
-  | Destructor :
-      { adt : 'ty_cst; case : int; cstr : 'term_cst; field: int; } ->
-      < ty_cst : 'ty_cst ; term_cst : 'term_cst; .. > t
-  (** [Destructor { adt; cstr; case; field; }] is the destructor returning the
-      field-th argument of the case-th constructor of type [adt] which should
-      be [cstr]. *)
+module Adt : sig
+  type _ t =
+    | Tester :
+        { adt: 'ty_cst; case: int; cstr : 'term_cst; } ->
+        < ty_cst : 'ty_cst ; term_cst : 'term_cst; .. > t
+    (** [Tester { adt; cstr; case; }] is the tester of the case-th constructor
+        of type [adt] which should be [cstr]. *)
+    | Constructor :
+        { adt : 'ty_cst; case : int; } ->
+        < ty_cst : 'ty_cst ; .. > t
+    (** [Constructor { adt; case}] is the case-th constructor of the algebraic
+        datatype defined by [adt]. *)
+    | Destructor :
+        { adt : 'ty_cst; case : int; cstr : 'term_cst; field: int; } ->
+        < ty_cst : 'ty_cst ; term_cst : 'term_cst; .. > t
+    (** [Destructor { adt; cstr; case; field; }] is the destructor returning the
+        field-th argument of the case-th constructor of type [adt] which should
+        be [cstr]. *)
+end
+
+type 'a t += Adt of 'a Adt.t
+(** Alegbraic datatype builtins. *)
 
 
 (** {2 HOL encoding Builtins} *)
 (*  ************************************************************************* *)
 
-type _ t +=
-  | Map
-  (** [Map: ttype -> ttype -> ttype] is the type for encoding higher order
-      functions into first order. An [(arg, ret) Map] is a first-order type
-      for encodings of functions from [arg] to [ret]. *)
-  | Map_app
-  (** [Map_app: 'arg 'ret. ('arg, 'ret) Map -> 'arg -> 'ret]:
-      Application operation for encodings of higher-order functions. *)
+module Map : sig
+  type _ t =
+    | T
+    (** [Map.T: ttype -> ttype -> ttype] is the type for encoding higher order
+        functions into first order. An [(arg, ret) Map.T] is a first-order type
+        for encodings of functions from [arg] to [ret]. *)
+    | App
+    (** [App: 'arg 'ret. ('arg, 'ret) Map.T -> 'arg -> 'ret]:
+        Application operation for encodings of higher-order functions. *)
+end
+
+type 'a t += Map of 'a Map.t
+(** Map/Higher-order encoding builtins. *)
 
 
 (** {2 Arithmetic Builtins} *)
 (*  ************************************************************************* *)
 
-type _ t +=
-  | Int
-  (** [Int: ttype] the type for signed integers of arbitrary precision. *)
-  | Integer of string
-  (** [Integer s: Int]: integer literal. The string [s] should be the
-      decimal representation of an integer with arbitrary precision (hence
-      the use of strings rather than the limited precision [int]). *)
-  | Rat
-  (** [Rat: ttype] the type for signed rationals. *)
-  | Rational of string
-  (** [Rational s: Rational]: rational literal. The string [s] should be
-      the decimal representation of a rational (see the various languages
-      spec for more information). *)
-  | Real
-  (** [Real: ttype] the type for signed reals. *)
-  | Decimal of string
-  (** [Decimal s: Real]: real literals. The string [s] should be a
-      floating point representation of a real. Not however that reals
-      here means the mathematical abstract notion of real numbers, including
-      irrational, non-algebric numbers, and is thus not restricted to
-      floating point numbers, although these are the only literals
-      supported.
+module Arith : sig
+  type _ t =
+    | Int
+    (** [Int: ttype] the type for signed integers of arbitrary precision. *)
+    | Integer of string
+    (** [Integer s: Int]: integer literal. The string [s] should be the
+        decimal representation of an integer with arbitrary precision (hence
+        the use of strings rather than the limited precision [int]). *)
+    | Rat
+    (** [Rat: ttype] the type for signed rationals. *)
+    | Rational of string
+    (** [Rational s: Rational]: rational literal. The string [s] should be
+        the decimal representation of a rational (see the various languages
+        spec for more information). *)
+    | Real
+    (** [Real: ttype] the type for signed reals. *)
+    | Decimal of string
+    (** [Decimal s: Real]: real literals. The string [s] should be a
+        floating point representation of a real. Not however that reals
+        here means the mathematical abstract notion of real numbers, including
+        irrational, non-algebric numbers, and is thus not restricted to
+        floating point numbers, although these are the only literals
+        supported.
 
-      Note that, in spite of the name, the literals may not be expressed in
-      decimal notation. For instance, [Decimal "0x1.0p1"] is a valid
-      representation for the real number [2].
+        Note that, in spite of the name, the literals may not be expressed in
+        decimal notation. For instance, [Decimal "0x1.0p1"] is a valid
+        representation for the real number [2].
 
-      Real literals can be parsed using ZArith's [Q.of_string]. *)
-  | Lt of [ `Int | `Rat | `Real ]
-  (** [Lt: {a=(Int|Rational|Real)} a -> a -> Prop]:
-      strict comparison (less than) on numbers
-      (whether integers, rationals, or reals). *)
-  | Leq of [ `Int | `Rat | `Real ]
-  (** [Leq:{a=(Int|Rational|Real)} a -> a -> Prop]:
-      large comparison (less or equal than) on numbers
-      (whether integers, rationals, or reals). *)
-  | Gt of [ `Int | `Rat | `Real ]
-  (** [Gt:{a=(Int|Rational|Real)} a -> a -> Prop]:
-      strict comparison (greater than) on numbers
-      (whether integers, rationals, or reals). *)
-  | Geq of [ `Int | `Rat | `Real ]
-  (** [Geq:{a=(Int|Rational|Real)} a -> a -> Prop]:
-      large comparison (greater or equal than) on numbers
-      (whether integers, rationals, or reals). *)
-  | Minus of [ `Int | `Rat | `Real ]
-  (** [Minus:{a=(Int|Rational|Real)} a -> a]:
-      arithmetic unary negation/minus on numbers
-      (whether integers, rationals, or reals). *)
-  | Add of [ `Int | `Rat | `Real ]
-  (** [Add:{a=(Int|Rational|Real)} a -> a -> a]:
-      arithmetic addition on numbers
-      (whether integers, rationals, or reals). *)
-  | Sub of [ `Int | `Rat | `Real ]
-  (** [Sub:{a=(Int|Rational|Real)} a -> a -> a]:
-      arithmetic substraction on numbers
-      (whether integers, rationals, or reals). *)
-  | Mul of [ `Int | `Rat | `Real ]
-  (** [Mul:{a=(Int|Rational|Real)} a -> a -> a]:
-      arithmetic multiplication on numbers
-      (whether integers, rationals, or reals). *)
-  | Pow of [ `Int | `Rat | `Real ]
-  (** [Pow:{a=(Int|Rational|Real)} a -> a -> a]:
-      arithmetic exponentiation on numbers
-      (whether integers, rationals, or reals). *)
-  | Div of [ `Rat | `Real ]
-  (** [Div:{a=(Rational|Real)} a -> a -> a]:
-      arithmetic exact division on numbers
-      (rationals, or reals, but **not** integers). *)
-  | Div_e of [ `Int | `Rat | `Real ]
-  (** [Div_e:{a=(Int|Rational|Real)} a -> a -> a]:
-      arithmetic integer euclidian quotient
-      (whether integers, rationals, or reals).
-      If D is positive then [Div_e (N,D)] is the floor
-      (in the type of N and D) of the real division [N/D],
-      and if D is negative then [Div_e (N,D)] is the ceiling
-      of [N/D]. *)
-  | Div_t of [ `Int | `Rat | `Real ]
-  (** [Div_t:{a=(Int|Rational|Real)} a -> a -> a]:
-      arithmetic integer truncated quotient
-      (whether integers, rationals, or reals).
-      [Div_t (N,D)] is the truncation of the real
-      division [N/D]. *)
-  | Div_f of [ `Int | `Rat | `Real ]
-  (** [Div_f:{a=(Int|Rational|Real)} a -> a -> a]:
-      arithmetic integer floor quotient
-      (whether integers, rationals, or reals).
-      [Div_t (N,D)] is the floor of the real
-      division [N/D]. *)
-  | Modulo_e of [ `Int | `Rat | `Real ]
-  (** [Modulo_e:{a=(Int|Rational|Real)} a -> a -> a]:
-      arithmetic integer euclidian remainder
-      (whether integers, rationals, or reals).
-      It is defined by the following equation:
-      [Div_e (N, D) * D + Modulo(N, D) = N]. *)
-  | Modulo_t of [ `Int | `Rat | `Real ]
-  (** [Modulo_t:{a=(Int|Rational|Real)} a -> a -> a]:
-      arithmetic integer truncated remainder
-      (whether integers, rationals, or reals).
-      It is defined by the following equation:
-      [Div_t (N, D) * D + Modulo_t(N, D) = N]. *)
-  | Modulo_f of [ `Int | `Rat | `Real ]
-  (** [Modulo_f:{a=(Int|Rational|Real)} a -> a -> a]:
-      arithmetic integer floor remainder
-      (whether integers, rationals, or reals).
-      It is defined by the following equation:
-      [Div_f (N, D) * D + Modulo_f(N, D) = N]. *)
-  | Abs
-  (** [Abs: Int -> Int]:
-      absolute value on integers. *)
-  | Divisible
-  (** [Divisible: Int -> Int -> Prop]:
-      divisibility predicate on integers. Smtlib restricts
-      applications of this predicate to have a litteral integer
-      for the divisor/second argument. *)
-  | Is_int of [ `Int | `Rat | `Real ]
-  (** [Is_int:{a=(Int|Rational|Real)} a -> Prop]:
-      integer predicate for numbers: is the given number
-      an integer. *)
-  | Is_rat of [ `Int | `Rat | `Real ]
-  (** [Is_rat:{a=(Int|Rational|Real)} a -> Prop]:
-      rational predicate for numbers: is the given number
-      an rational. *)
-  | Floor of [ `Int | `Rat | `Real ]
-  (** [Floor:{a=(Int|Rational|Real)} a -> a]:
-      floor function on numbers, defined in tptp as
-      the largest integer not greater than the argument. *)
-  | Floor_to_int of [ `Rat | `Real ]
-  (** [Floor_to_int:{a=(Rational|Real)} a -> Int]:
-      floor and conversion to integers in a single function.
-      Should return the greatest integer [i] such that the
-      rational or real intepretation of [i] is less than, or
-      equal to, the argument. *)
-  | Ceiling of [ `Int | `Rat | `Real ]
-  (** [Ceiling:{a=(Int|Rational|Real)} a -> a]:
-      ceiling function on numbers, defined in tptp as
-      the smallest integer not less than the argument. *)
-  | Truncate of [ `Int | `Rat | `Real ]
-  (** [Truncate:{a=(Int|Rational|Real)} a -> a]:
-      ceiling function on numbers, defined in tptp as
-      the nearest integer value with magnitude not greater
-      than the absolute value of the argument. *)
-  | Round of [ `Int | `Rat | `Real ]
-  (** [Round:{a=(Int|Rational|Real)} a -> a]:
-      rounding function on numbers, defined in tptp as
-      the nearest intger to the argument; when the argument
-      is halfway between two integers, the nearest even integer
-      to the argument. *)
+        Real literals can be parsed using ZArith's [Q.of_string]. *)
+    | Lt of [ `Int | `Rat | `Real ]
+    (** [Lt: {a=(Int|Rational|Real)} a -> a -> Prop.T]:
+        strict comparison (less than) on numbers
+        (whether integers, rationals, or reals). *)
+    | Leq of [ `Int | `Rat | `Real ]
+    (** [Leq:{a=(Int|Rational|Real)} a -> a -> Prop.T]:
+        large comparison (less or equal than) on numbers
+        (whether integers, rationals, or reals). *)
+    | Gt of [ `Int | `Rat | `Real ]
+    (** [Gt:{a=(Int|Rational|Real)} a -> a -> Prop.T]:
+        strict comparison (greater than) on numbers
+        (whether integers, rationals, or reals). *)
+    | Geq of [ `Int | `Rat | `Real ]
+    (** [Geq:{a=(Int|Rational|Real)} a -> a -> Prop.T]:
+        large comparison (greater or equal than) on numbers
+        (whether integers, rationals, or reals). *)
+    | Minus of [ `Int | `Rat | `Real ]
+    (** [Minus:{a=(Int|Rational|Real)} a -> a]:
+        arithmetic unary negation/minus on numbers
+        (whether integers, rationals, or reals). *)
+    | Add of [ `Int | `Rat | `Real ]
+    (** [Add:{a=(Int|Rational|Real)} a -> a -> a]:
+        arithmetic addition on numbers
+        (whether integers, rationals, or reals). *)
+    | Sub of [ `Int | `Rat | `Real ]
+    (** [Sub:{a=(Int|Rational|Real)} a -> a -> a]:
+        arithmetic substraction on numbers
+        (whether integers, rationals, or reals). *)
+    | Mul of [ `Int | `Rat | `Real ]
+    (** [Mul:{a=(Int|Rational|Real)} a -> a -> a]:
+        arithmetic multiplication on numbers
+        (whether integers, rationals, or reals). *)
+    | Pow of [ `Int | `Real ]
+    (** [Pow:{a=(Int|Real)} a -> a -> a]:
+        arithmetic exponentiation on numbers
+        (whether integers or reals). *)
+    | Div of [ `Rat | `Real ]
+    (** [Div:{a=(Rational|Real)} a -> a -> a]:
+        arithmetic exact division on numbers
+        (rationals, or reals, but **not** integers). *)
+    | Div_e of [ `Int | `Rat | `Real ]
+    (** [Div_e:{a=(Int|Rational|Real)} a -> a -> a]:
+        arithmetic integer euclidian quotient
+        (whether integers, rationals, or reals).
+        If D is positive then [Div_e (N,D)] is the floor
+        (in the type of N and D) of the real division [N/D],
+        and if D is negative then [Div_e (N,D)] is the ceiling
+        of [N/D]. *)
+    | Modulo_e of [ `Int | `Rat | `Real ]
+    (** [Modulo_e:{a=(Int|Rational|Real)} a -> a -> a]:
+        arithmetic integer euclidian remainder
+        (whether integers, rationals, or reals).
+        It is defined by the following equation:
+        [Div_e (N, D) * D + Modulo(N, D) = N]. *)
+    | Div_t of [ `Int | `Rat | `Real ]
+    (** [Div_t:{a=(Int|Rational|Real)} a -> a -> a]:
+        arithmetic integer truncated quotient
+        (whether integers, rationals, or reals).
+        [Div_t (N,D)] is the truncation of the real
+        division [N/D]. *)
+    | Modulo_t of [ `Int | `Rat | `Real ]
+    (** [Modulo_t:{a=(Int|Rational|Real)} a -> a -> a]:
+        arithmetic integer truncated remainder
+        (whether integers, rationals, or reals).
+        It is defined by the following equation:
+        [Div_t (N, D) * D + Modulo_t(N, D) = N]. *)
+    | Div_f of [ `Int | `Rat | `Real ]
+    (** [Div_f:{a=(Int|Rational|Real)} a -> a -> a]:
+        arithmetic integer floor quotient
+        (whether integers, rationals, or reals).
+        [Div_t (N,D)] is the floor of the real
+        division [N/D]. *)
+    | Modulo_f of [ `Int | `Rat | `Real ]
+    (** [Modulo_f:{a=(Int|Rational|Real)} a -> a -> a]:
+        arithmetic integer floor remainder
+        (whether integers, rationals, or reals).
+        It is defined by the following equation:
+        [Div_f (N, D) * D + Modulo_f(N, D) = N]. *)
+    | Abs
+    (** [Abs: Int -> Int]:
+        absolute value on integers. *)
+    | Divisible
+    (** [Divisible: Int -> Int -> Prop.T]:
+        divisibility predicate on integers. Smtlib restricts
+        applications of this predicate to have a litteral integer
+        for the divisor/second argument. *)
+    | Is_int of [ `Int | `Rat | `Real ]
+    (** [Is_int:{a=(Int|Rational|Real)} a -> Prop.T]:
+        integer predicate for numbers: is the given number
+        an integer. *)
+    | Is_rat of [ `Int | `Rat | `Real ]
+    (** [Is_rat:{a=(Int|Rational|Real)} a -> Prop.T]:
+        rational predicate for numbers: is the given number
+        an rational. *)
+    | Floor of [ `Int | `Rat | `Real ]
+    (** [Floor:{a=(Int|Rational|Real)} a -> a]:
+        floor function on numbers, defined in tptp as
+        the largest integer not greater than the argument. *)
+    | Floor_to_int of [ `Rat | `Real ]
+    (** [Floor_to_int:{a=(Rational|Real)} a -> Int]:
+        floor and conversion to integers in a single function.
+        Should return the greatest integer [i] such that the
+        rational or real intepretation of [i] is less than, or
+        equal to, the argument. *)
+    | Ceiling of [ `Int | `Rat | `Real ]
+    (** [Ceiling:{a=(Int|Rational|Real)} a -> a]:
+        ceiling function on numbers, defined in tptp as
+        the smallest integer not less than the argument. *)
+    | Truncate of [ `Int | `Rat | `Real ]
+    (** [Truncate:{a=(Int|Rational|Real)} a -> a]:
+        ceiling function on numbers, defined in tptp as
+        the nearest integer value with magnitude not greater
+        than the absolute value of the argument. *)
+    | Round of [ `Int | `Rat | `Real ]
+    (** [Round:{a=(Int|Rational|Real)} a -> a]:
+        rounding function on numbers, defined in tptp as
+        the nearest intger to the argument; when the argument
+        is halfway between two integers, the nearest even integer
+        to the argument. *)
+end
+
+type 'a t += Arith of 'a Arith.t
+(** Arithmetic builtins. *)
 
 
 (** {2 Arrays Builtins} *)
 (*  ************************************************************************* *)
 
-type _ t +=
-  | Array
-  (** [Array: ttype -> ttype -> ttype]: the type constructor for
-      polymorphic functional arrays. An [(src, dst) Array] is an array
-      from expressions of type [src] to expressions of type [dst].
-      Typically, such arrays are immutables. *)
-  | Const
-  (** [Store: 'a 'b. 'b -> ('a, 'b) Array]: returns a constant array,
-      which maps any value of type ['a] to the given base value. *)
-  | Store
-  (** [Store: 'a 'b. ('a, 'b) Array -> 'a -> 'b -> ('a, 'b) Array]:
-      store operation on arrays. Returns a new array with the key bound
-      to the given value (shadowing the previous value associated to
-      the key). *)
-  | Select
-  (** [Select: 'a 'b. ('a, 'b) Array -> 'a -> 'b]:
-      select operation on arrays. Returns the value associated to the
-      given key. Typically, functional arrays are complete, i.e. all
-      keys are mapped to a value. *)
+module Array : sig
+  type _ t =
+    | T
+    (** [Array.T: ttype -> ttype -> ttype]: the type constructor for
+        polymorphic functional arrays. An [(src, dst) Array] is an array
+        from expressions of type [src] to expressions of type [dst].
+        Typically, such arrays are immutables. *)
+    | Const
+    (** [Store: 'a 'b. 'b -> ('a, 'b) Array.T]: returns a constant array,
+        which maps any value of type ['a] to the given base value. *)
+    | Store
+    (** [Store: 'a 'b. ('a, 'b) Array.T -> 'a -> 'b -> ('a, 'b) Array.T]:
+        store operation on arrays. Returns a new array with the key bound
+        to the given value (shadowing the previous value associated to
+        the key). *)
+    | Select
+    (** [Select: 'a 'b. ('a, 'b) Array.T -> 'a -> 'b]:
+        select operation on arrays. Returns the value associated to the
+        given key. Typically, functional arrays are complete, i.e. all
+        keys are mapped to a value. *)
+end
+
+type 'a t += Array of 'a Array.t
+(** Array builtins. *)
 
 
 (** {2 Bitvectors Builtins} *)
 (*  ************************************************************************* *)
 
-type _ t +=
-  | Bitv of int
-  (** [Bitv n: ttype]: type constructor for bitvectors of length [n].
-      Ensures that [n > 0]. *)
-  | Bitvec of string
-  (** [Bitvec s: Bitv]: bitvector litteral. The string [s] should
-      be a binary representation of bitvectors using characters
-      ['0'], and ['1'] (lsb last) *)
-  | Bitv_to_int of { n : int; signed : bool; }
-  (** [Bitv_to_int(n,signed): Bitv(n) -> Int]:
-      conversion from bitvectors to signed integers. *)
-  | Bitv_of_int of { n : int; }
-  (** [Bitv_of_int(n): Int -> Bitv(n)]:
-      conversion fromm (signed) integers to bitvectors. *)
-  | Bitv_concat of { n : int; m : int }
-  (** [Bitv_concat(n,m): Bitv(n) -> Bitv(m) -> Bitv(n+m)]:
-      concatenation operator on bitvectors. *)
-  | Bitv_extract of { n : int; i : int; j : int }
-  (** [Bitv_extract(n, i, j): Bitv(n) -> Bitv(i - j + 1)]:
-      bitvector extraction, from index [j] up to [i] (both included).
-      Ensures that [0 <= j <= i < n]. *)
-  | Bitv_repeat of { n : int; k : int }
-  (** [Bitv_repeat(n,k): Bitv(n) -> Bitv(n*k)]:
-      bitvector repeatition. *)
-  | Bitv_zero_extend of { n : int; k : int }
-  (** [Bitv_zero_extend(n,k): Bitv(n) -> Bitv(n + k)]:
-      zero extension for bitvectors (produces a representation of the
-      same unsigned integer). *)
-  | Bitv_sign_extend of { n : int; k : int }
-  (** [Bitv_sign_extend(n,k): Bitv(n) -> Bitv(n + k)]:
-      sign extension for bitvectors ((produces a representation of the
-      same signed integer). *)
-  | Bitv_rotate_right of { n : int; i : int }
-  (** [Bitv_rotate_right(n,i): Bitv(n) -> Bitv(n)]:
-      logical rotate right for bitvectors by [i]. *)
-  | Bitv_rotate_left of { n : int; i : int }
-  (** [Bitv_rotate_left(n,i): Bitv(n) -> Bitv(n)]:
-      logical rotate left for bitvectors by [i]. *)
-  | Bitv_not of int
-  (** [Bitv_not(n): Bitv(n) -> Bitv(n)]:
-      bitwise negation for bitvectors. *)
-  | Bitv_and of int
-  (** [Bitv_and(n): Bitv(n) -> Bitv(n) -> Bitv(n)]:
-      bitwise conjunction for bitvectors. *)
-  | Bitv_or of int
-  (** [bitv_or(n): Bitv(n) -> Bitv(n) -> Bitv(n)]:
-      bitwise disjunction for bitvectors. *)
-  | Bitv_nand of int
-  (** [Bitv_nand(n): Bitv(n) -> Bitv(n) -> Bitv(n)]:
-      bitwise negated conjunction for bitvectors.
-      [Bitv_nand s t] abbreviates [Bitv_not (Bitv_and s t))]. *)
-  | Bitv_nor of int
-  (** [Bitv_nor(n): Bitv(n) -> Bitv(n) -> Bitv(n)]:
-      bitwise negated disjunction for bitvectors.
-      [Bitv_nor s t] abbreviates [Bitv_not (Bitv_or s t))]. *)
-  | Bitv_xor of int
-  (** [Bitv_xor(n): Bitv(n) -> Bitv(n) -> Bitv(n)]:
-      bitwise exclusive disjunction for bitvectors.
-      [Bitv_xor s t] abbreviates
-      [Bitv_or (Bitv_and s (Bitv_not t))
-               (Bitv_and (Bitv_not s) t) ]. *)
-  | Bitv_xnor of int
-  (** [Bitv_xnor(n): Bitv(n) -> Bitv(n) -> Bitv(n)]:
-      bitwise negated exclusive disjunction for bitvectors.
-      [Bitv_xnor s t] abbreviates
-      [Bitv_or (Bitv_and s t)
-               (Bitv_and (Bitv_not s) (Bitv_not t))]. *)
-  | Bitv_comp of int
-  (** [Bitv_comp(n): Bitv(n) -> Bitv(n) -> Bitv(1)]:
-      Returns the constant bitvector ["1"] is all bits are equal,
-      and the bitvector ["0"] if not. *)
-  | Bitv_neg of int
-  (** [Bitv_neg(n): Bitv(n) -> Bitv(n)]:
-      2's complement unary minus. *)
-  | Bitv_add of int
-  (** [Bitv_add(n): Bitv(n) -> Bitv(n) -> Bitv(n)]:
-      addition modulo 2^n. *)
-  | Bitv_sub of int
-  (** [Bitv_sub(n): Bitv(n) -> Bitv(n) -> Bitv(n)]:
-      2's complement subtraction modulo 2^n. *)
-  | Bitv_mul of int
-  (** [Bitv_mul(n): Bitv(n) -> Bitv(n) -> Bitv(n)]:
-      multiplication modulo 2^n. *)
-  | Bitv_udiv of int
-  (** [Bitv_udiv(n): Bitv(n) -> Bitv(n) -> Bitv(n)]:
-      unsigned division, truncating towards 0. *)
-  | Bitv_urem of int
-  (** [Bitv_urem(n): Bitv(n) -> Bitv(n) -> Bitv(n)]:
-      unsigned remainder from truncating division. *)
-  | Bitv_sdiv of int
-  (** [Bitv_sdiv(n): Bitv(n) -> Bitv(n) -> Bitv(n)]:
-      2's complement signed division. *)
-  | Bitv_srem of int
-  (** [Bitv_srem(n): Bitv(n) -> Bitv(n) -> Bitv(n)]:
-      2's complement signed remainder (sign follows dividend). *)
-  | Bitv_smod of int
-  (** [Bitv_smod(n): Bitv(n) -> Bitv(n) -> Bitv(n)]:
-      2's complement signed remainder (sign follows divisor). *)
-  | Bitv_shl of int
-  (** [Bitv_shl(n): Bitv(n) -> Bitv(n) -> Bitv(n)]:
-      shift left (equivalent to multiplication by 2^x where x
-      is the value of the second argument). *)
-  | Bitv_lshr of int
-  (** [Bitv_lshr(n): Bitv(n) -> Bitv(n) -> Bitv(n)]:
-      logical shift right (equivalent to unsigned division by 2^x,
-      where x is the value of the second argument). *)
-  | Bitv_ashr of int
-  (** [Bitv_ashr(n): Bitv(n) -> Bitv(n) -> Bitv(n)]:
-      Arithmetic shift right, like logical shift right except that
-      the most significant bits of the result always copy the most
-      significant bit of the first argument. *)
-  | Bitv_ult of int
-  (** [Bitv_ult(n): Bitv(n) -> Bitv(n) -> Prop]:
-      binary predicate for unsigned less-than. *)
-  | Bitv_ule of int
-  (** [Bitv_ule(n): Bitv(n) -> Bitv(n) -> Prop]:
-      binary predicate for unsigned less than or equal. *)
-  | Bitv_ugt of int
-  (** [Bitv_ugt(n): Bitv(n) -> Bitv(n) -> Prop]:
-      binary predicate for unsigned greater-than. *)
-  | Bitv_uge of int
-  (** [Bitv_uge(n): Bitv(n) -> Bitv(n) -> Prop]:
-      binary predicate for unsigned greater than or equal. *)
-  | Bitv_slt of int
-  (** [Bitv_slt(n): Bitv(n) -> Bitv(n) -> Prop]:
-      binary predicate for signed less-than. *)
-  | Bitv_sle of int
-  (** [Bitv_sle(n): Bitv(n) -> Bitv(n) -> Prop]:
-      binary predicate for signed less than or equal. *)
-  | Bitv_sgt of int
-  (** [Bitv_sgt(n): Bitv(n) -> Bitv(n) -> Prop]:
-      binary predicate for signed greater-than. *)
-  | Bitv_sge of int
-  (** [Bitv_sge(n): Bitv(n) -> Bitv(n) -> Prop]:
-      binary predicate for signed greater than or equal. *)
-  | Bitv_overflow_neg of { n : int; }
-  (** [Bitv_overflow_neg(n) : Bitv(n) -> Prop]:
-      unary overflow predicate for signed unary minus
-      (i.e. returns [true] if the negation would overflow) *)
-  | Bitv_overflow_add of { n : int; signed : bool; }
-  (** [Bitv_overflow_add(n,signed) : Bitv(n) -> Bitv(n) -> Prop]:
-      binary overflow predicate for signed/unsigned addition
-      (i.e. returns [true] if the operation would overflow) *)
-  | Bitv_overflow_sub of { n : int; signed : bool; }
-  (** [Bitv_overflow_sub(n,signed): Bitv(n) -> Bitv(n) -> Prop
-      binary overflow predicate for signed/unsigned subtraction
-      (i.e. returns [true] if the operation would overflow) *)
-  | Bitv_overflow_mul of { n : int; signed : bool; }
-  (** [Bitv_overflow_mul(n,signed): Bitv(n) -> Bitv(n) -> Prop
-      binary overflow predicate for signed/unsigned multiplication
-      (i.e. returns [true] if the operation would overflow) *)
-  | Bitv_overflow_div of { n : int; }
-  (** [Bitv_overflow_mul(n,signed): Bitv(n) -> Bitv(n) -> Prop
-      binary overflow predicate for signed division
-      (i.e. returns [true] if the operation would overflow) *)
+module Bitv : sig
+  type _ t =
+    | T of int
+    (** [Bitv.T n: ttype]: type constructor for bitvectors of length [n].
+        Ensures that [n > 0]. *)
+    | Binary_lit of string
+    (** [Lit s: Bitv.T]: bitvector litteral. The string [s] should
+        be a binary representation of bitvectors using characters
+        ['0'], and ['1'] (lsb last) *)
+    | To_int of { n : int; signed : bool; }
+    (** [To_int(n,signed): Bitv.T(n) -> Int]:
+        conversion from bitvectors to signed integers. *)
+    | Of_int of { n : int; }
+    (** [Of_int(n): Int -> Bitv.T(n)]:
+        conversion fromm (signed) integers to bitvectors. *)
+    | Concat of { n : int; m : int }
+    (** [Concat(n,m): Bitv.T(n) -> Bitv.T(m) -> Bitv.T(n+m)]:
+        concatenation operator on bitvectors. *)
+    | Extract of { n : int; i : int; j : int }
+    (** [Extract(n, i, j): Bitv.T(n) -> Bitv.T(i - j + 1)]:
+        bitvector extraction, from index [j] up to [i] (both included).
+        Ensures that [0 <= j <= i < n]. *)
+    | Repeat of { n : int; k : int }
+    (** [Repeat(n,k): Bitv.T(n) -> Bitv.T(n*k)]:
+        bitvector repeatition. *)
+    | Zero_extend of { n : int; k : int }
+    (** [Zero_extend(n,k): Bitv.T(n) -> Bitv.T(n + k)]:
+        zero extension for bitvectors (produces a representation of the
+        same unsigned integer). *)
+    | Sign_extend of { n : int; k : int }
+    (** [Sign_extend(n,k): Bitv.T(n) -> Bitv.T(n + k)]:
+        sign extension for bitvectors ((produces a representation of the
+        same signed integer). *)
+    | Rotate_right of { n : int; i : int }
+    (** [Rotate_right(n,i): Bitv.T(n) -> Bitv.T(n)]:
+        logical rotate right for bitvectors by [i]. *)
+    | Rotate_left of { n : int; i : int }
+    (** [Rotate_left(n,i): Bitv.T(n) -> Bitv.T(n)]:
+        logical rotate left for bitvectors by [i]. *)
+    | Not of int
+    (** [not(n): Bitv.T(n) -> Bitv.T(n)]:
+        bitwise negation for bitvectors. *)
+    | And of int
+    (** [and(n): Bitv.T(n) -> Bitv.T(n) -> Bitv.T(n)]:
+        bitwise conjunction for bitvectors. *)
+    | Or of int
+    (** [bitv_or(n): Bitv.T(n) -> Bitv.T(n) -> Bitv.T(n)]:
+        bitwise disjunction for bitvectors. *)
+    | Nand of int
+    (** [nand(n): Bitv.T(n) -> Bitv.T(n) -> Bitv.T(n)]:
+        bitwise negated conjunction for bitvectors.
+        [Nand s t] abbreviates [Not (And s t))]. *)
+    | Nor of int
+    (** [Nor(n): Bitv.T(n) -> Bitv.T(n) -> Bitv.T(n)]:
+        bitwise negated disjunction for bitvectors.
+        [Nor s t] abbreviates [Not (Or s t))]. *)
+    | Xor of int
+    (** [Xor(n): Bitv.T(n) -> Bitv.T(n) -> Bitv.T(n)]:
+        bitwise exclusive disjunction for bitvectors.
+        [Xor s t] abbreviates
+        [Or (And s (Not t)) (And (Not s) t) ]. *)
+    | Xnor of int
+    (** [Xnor(n): Bitv.T(n) -> Bitv.T(n) -> Bitv.T(n)]:
+        bitwise negated exclusive disjunction for bitvectors.
+        [Xnor s t] abbreviates
+        [Or (And s t) (And (Not s) (Not t))]. *)
+    | Comp of int
+    (** [Comp(n): Bitv.T(n) -> Bitv.T(n) -> Bitv.T(1)]:
+        Returns the constant bitvector ["1"] is all bits are equal,
+        and the bitvector ["0"] if not. *)
+    | Neg of int
+    (** [Neg(n): Bitv.T(n) -> Bitv.T(n)]:
+        2's complement unary minus. *)
+    | Add of int
+    (** [Add(n): Bitv.T(n) -> Bitv.T(n) -> Bitv.T(n)]:
+        addition modulo 2^n. *)
+    | Sub of int
+    (** [Sub(n): Bitv.T(n) -> Bitv.T(n) -> Bitv.T(n)]:
+        2's complement subtraction modulo 2^n. *)
+    | Mul of int
+    (** [Mul(n): Bitv.T(n) -> Bitv.T(n) -> Bitv.T(n)]:
+        multiplication modulo 2^n. *)
+    | Udiv of int
+    (** [Udiv(n): Bitv.T(n) -> Bitv.T(n) -> Bitv.T(n)]:
+        unsigned division, truncating towards 0. *)
+    | Urem of int
+    (** [Urem(n): Bitv.T(n) -> Bitv.T(n) -> Bitv.T(n)]:
+        unsigned remainder from truncating division. *)
+    | Sdiv of int
+    (** [Sdiv(n): Bitv.T(n) -> Bitv.T(n) -> Bitv.T(n)]:
+        2's complement signed division. *)
+    | Srem of int
+    (** [Srem(n): Bitv.T(n) -> Bitv.T(n) -> Bitv.T(n)]:
+        2's complement signed remainder (sign follows dividend). *)
+    | Smod of int
+    (** [Smod(n): Bitv.T(n) -> Bitv.T(n) -> Bitv.T(n)]:
+        2's complement signed remainder (sign follows divisor). *)
+    | Shl of int
+    (** [Shl(n): Bitv.T(n) -> Bitv.T(n) -> Bitv.T(n)]:
+        shift left (equivalent to multiplication by 2^x where x
+        is the value of the second argument). *)
+    | Lshr of int
+    (** [Lshr(n): Bitv.T(n) -> Bitv.T(n) -> Bitv.T(n)]:
+        logical shift right (equivalent to unsigned division by 2^x,
+        where x is the value of the second argument). *)
+    | Ashr of int
+    (** [Ashr(n): Bitv.T(n) -> Bitv.T(n) -> Bitv.T(n)]:
+        Arithmetic shift right, like logical shift right except that
+        the most significant bits of the result always copy the most
+        significant bit of the first argument. *)
+    | Ult of int
+    (** [Ult(n): Bitv.T(n) -> Bitv.T(n) -> Prop.T]:
+        binary predicate for unsigned less-than. *)
+    | Ule of int
+    (** [ule(n): Bitv.T(n) -> Bitv.T(n) -> Prop.T]:
+        binary predicate for unsigned less than or equal. *)
+    | Ugt of int
+    (** [Ugt(n): Bitv.T(n) -> Bitv.T(n) -> Prop.T]:
+        binary predicate for unsigned greater-than. *)
+    | Uge of int
+    (** [Uge(n): Bitv.T(n) -> Bitv.T(n) -> Prop.T]:
+        binary predicate for unsigned greater than or equal. *)
+    | Slt of int
+    (** [Slt(n): Bitv.T(n) -> Bitv.T(n) -> Prop.T]:
+        binary predicate for signed less-than. *)
+    | Sle of int
+    (** [Sle(n): Bitv.T(n) -> Bitv.T(n) -> Prop.T]:
+        binary predicate for signed less than or equal. *)
+    | Sgt of int
+    (** [Sgt(n): Bitv.T(n) -> Bitv.T(n) -> Prop.T]:
+        binary predicate for signed greater-than. *)
+    | Sge of int
+    (** [Sge(n): Bitv.T(n) -> Bitv.T(n) -> Prop.T]:
+        binary predicate for signed greater than or equal. *)
+    | Overflow_neg of { n : int; }
+    (** [Overflow_neg(n) : Bitv.T(n) -> Prop.T]:
+        unary overflow predicate for signed unary minus
+        (i.e. returns [true] if the negation would overflow) *)
+    | Overflow_add of { n : int; signed : bool; }
+    (** [Overflow_add(n,signed) : Bitv.T(n) -> Bitv.T(n) -> Prop.T]:
+        binary overflow predicate for signed/unsigned addition
+        (i.e. returns [true] if the operation would overflow) *)
+    | Overflow_sub of { n : int; signed : bool; }
+    (** [Overflow_sub(n,signed): Bitv.T(n) -> Bitv.T(n) -> Prop.T
+        binary overflow predicate for signed/unsigned subtraction
+        (i.e. returns [true] if the operation would overflow) *)
+    | Overflow_mul of { n : int; signed : bool; }
+    (** [Overflow_mul(n,signed): Bitv.T(n) -> Bitv.T(n) -> Prop.T
+        binary overflow predicate for signed/unsigned multiplication
+        (i.e. returns [true] if the operation would overflow) *)
+    | Overflow_div of { n : int; }
+    (** [Overflow_mul(n,signed): Bitv.T(n) -> Bitv.T(n) -> Prop.T
+        binary overflow predicate for signed division
+        (i.e. returns [true] if the operation would overflow) *)
+end
+
+type 'a t += Bitv of 'a Bitv.t
+(** Bitvectors builtins *)
 
 
 (** {2 Floats Builtins} *)
 (*  ************************************************************************* *)
 
-type _ t +=
-  | RoundingMode
-  (** [RoundingMode: ttype]: type for enumerated type of rounding modes. *)
-  | RoundNearestTiesToEven
-  (** [RoundNearestTiesToEven : RoundingMode]: *)
-  | RoundNearestTiesToAway
-  (** [RoundNearestTiesToAway : RoundingMode]: *)
-  | RoundTowardPositive
-  (** [RoundTowardPositive : RoundingMode *)
-  | RoundTowardNegative
-  (** [RoundTowardNegative : RoundingMode *)
-  | RoundTowardZero
-  (** [RoundTowardZero : RoundingMode *)
-  | Float of int * int
-  (** [Float(e,s): ttype]: type constructor for floating point of exponent of
-      size [e] and significand of size [s] (hidden bit included). Those size are
-      greater than 1 *)
-  | Fp of int * int
-  (** [Fp(e, s): Bitv(1) -> Bitv(e) -> Bitv(s-1) -> Fp(e,s)]: bitvector literal.
-      The IEEE-format is used for the conversion [sb^se^ss].
-      All the NaN are converted to the same value. *)
-  | Plus_infinity of int * int
-  (** [Plus_infinity(s,e) : Fp(s,e)] *)
-  | Minus_infinity of int * int
-  (** [Minus_infinity(s,e) : Fp(s,e)] *)
-  | Plus_zero of int * int
-  (** [Plus_zero(s,e) : Fp(s,e)] *)
-  | Minus_zero of int * int
-  (** [Minus_zero(s,e) : Fp(s,e)] *)
-  | NaN of int * int
-  (** [NaN(s,e) : Fp(s,e)] *)
-  | Fp_abs  of int * int
-  (** [Fp_abs(s,e): Fp(s,e) -> Fp(s,e)]: absolute value *)
-  | Fp_neg  of int * int
-  (** [Fp_neg(s,e): Fp(s,e) -> Fp(s,e)]: negation *)
-  | Fp_add  of int * int
-  (** [Fp_add(s,e): RoundingMode -> Fp(s,e) -> Fp(s,e) -> Fp(s,e)]: addition *)
-  | Fp_sub  of int * int
-  (** [Fp_sub(s,e): RoundingMode -> Fp(s,e) -> Fp(s,e) -> Fp(s,e)]: subtraction *)
-  | Fp_mul  of int * int
-  (** [Fp_mul(s,e): RoundingMode -> Fp(s,e) -> Fp(s,e) -> Fp(s,e)]: multiplication *)
-  | Fp_div  of int * int
-  (** [Fp_div(s,e): RoundingMode -> Fp(s,e) -> Fp(s,e) -> Fp(s,e)]: division *)
-  | Fp_fma  of int * int
-  (** [Fp_fma(s,e): RoundingMode -> Fp(s,e) -> Fp(s,e)]: fuse multiply add *)
-  | Fp_sqrt  of int * int
-  (** [Fp_sqrt(s,e): RoundingMode -> Fp(s,e) -> Fp(s,e)]: square root *)
-  | Fp_rem  of int * int
-  (** [Fp_rem(s,e): Fp(s,e) -> Fp(s,e) -> Fp(s,e)]: remainder *)
-  | Fp_roundToIntegral  of int * int
-  (** [Fp_roundToIntegral(s,e): RoundingMode -> Fp(s,e) -> Fp(s,e)]: round to integral *)
-  | Fp_min  of int * int
-  (** [Fp_min(s,e): Fp(s,e) -> Fp(s,e) -> Fp(s,e)]: minimum *)
-  | Fp_max  of int * int
-  (** [Fp_max(s,e): Fp(s,e) -> Fp(s,e) -> Fp(s,e)]: maximum *)
-  | Fp_leq  of int * int
-  (** [Fp_leq(s,e): Fp(s,e) -> Fp(s,e) -> Prop]: IEEE less or equal *)
-  | Fp_lt  of int * int
-  (** [Fp_lt(s,e): Fp(s,e) -> Fp(s,e) -> Prop]: IEEE less than *)
-  | Fp_geq  of int * int
-  (** [Fp_geq(s,e): Fp(s,e) -> Fp(s,e) -> Prop]: IEEE greater or equal *)
-  | Fp_gt  of int * int
-  (** [Fp_gt(s,e): Fp(s,e) -> Fp(s,e) -> Prop]: IEEE greater than *)
-  | Fp_eq  of int * int
-  (** [Fp_eq(s,e): Fp(s,e) -> Fp(s,e) -> Prop]: IEEE equality *)
-  | Fp_isNormal  of int * int
-  (** [Fp_isNormal(s,e): Fp(s,e) -> Prop]: test if it is a normal floating point *)
-  | Fp_isSubnormal  of int * int
-  (** [Fp_isSubnormal(s,e): Fp(s,e) -> Prop]: test if it is a subnormal floating point *)
-  | Fp_isZero  of int * int
-  (** [Fp_isZero(s,e): Fp(s,e) -> Prop]: test if it is a zero *)
-  | Fp_isInfinite  of int * int
-  (** [Fp_isInfinite(s,e): Fp(s,e) -> Prop]: test if it is an infinite *)
-  | Fp_isNaN  of int * int
-  (** [Fp_isNaN(s,e): Fp(s,e) -> Prop]: test if it is Not a Number *)
-  | Fp_isNegative  of int * int
-  (** [Fp_isNegative(s,e): Fp(s,e) -> Prop]: test if it is negative *)
-  | Fp_isPositive  of int * int
-  (** [Fp_isPositive(s,e): Fp(s,e) -> Prop]: test if it is positive *)
-  | Ieee_format_to_fp of int * int
-  (** [Ieee_format_to_fp(s,e): Bv(s+e) -> Fp(s,e)]: Convert from IEEE interchange format *)
-  | Fp_to_fp of int * int * int * int
-  (** [Fp_to_fp(s1,e1,s2,e2): RoundingMode -> Fp(s1,e1) -> Fp(s2,e2)]: Convert from another floating point format *)
-  | Real_to_fp of int * int
-  (** [Real_to_fp(s,e): RoundingMode -> Real -> Fp(s,e)]: Convert from a real *)
-  | Sbv_to_fp of int * int * int
-  (** [Sbv_to_fp(m,s,e): RoundingMode -> Bitv(m) -> Fp(s,e)]: Convert from a signed integer *)
-  | Ubv_to_fp of int * int * int
-  (** [Ubv_to_fp(m,s,e): RoundingMode -> Bitv(m) -> Fp(s,e)]: Convert from a unsigned integer *)
-  | To_ubv of int * int * int
-  (** [To_ubv(s,e,m): RoundingMode -> Fp(s,e) -> Bitv(m)]: Convert to an unsigned integer *)
-  | To_sbv of int * int * int
-  (** [To_ubv(s,e,m): RoundingMode -> Fp(s,e) -> Bitv(m)]: Convert to an signed integer *)
-  | To_real of int * int
-  (** [To_real(s,e): Fp(s,e) -> Real]: Convert to real *)
+module Float : sig
+  type _ t =
+    | T of int * int
+    (** [Float(e,s): ttype]: type constructor for floating point of exponent of
+        size [e] and significand of size [s] (hidden bit included). Those size are
+        greater than 1 *)
+    | RoundingMode
+    (** [RoundingMode: ttype]: type for enumerated type of rounding modes. *)
+    | Fp of int * int
+    (** [Fp(e, s): Bitv.T(1) -> Bitv.T(e) -> Bitv.T(s-1) -> Fp(e,s)]: bitvector literal.
+        The IEEE-format is used for the conversion [sb^se^ss].
+        All the NaN are converted to the same value. *)
+    | RoundNearestTiesToEven
+    (** [RoundNearestTiesToEven : RoundingMode]: *)
+    | RoundNearestTiesToAway
+    (** [RoundNearestTiesToAway : RoundingMode]: *)
+    | RoundTowardPositive
+    (** [RoundTowardPositive : RoundingMode *)
+    | RoundTowardNegative
+    (** [RoundTowardNegative : RoundingMode *)
+    | RoundTowardZero
+    (** [RoundTowardZero : RoundingMode *)
+    | Plus_infinity of int * int
+    (** [Plus_infinity(s,e) : Fp(s,e)] *)
+    | Minus_infinity of int * int
+    (** [Minus_infinity(s,e) : Fp(s,e)] *)
+    | Plus_zero of int * int
+    (** [Plus_zero(s,e) : Fp(s,e)] *)
+    | Minus_zero of int * int
+    (** [Minus_zero(s,e) : Fp(s,e)] *)
+    | NaN of int * int
+    (** [NaN(s,e) : Fp(s,e)] *)
+    | Abs  of int * int
+    (** [Fp_abs(s,e): Fp(s,e) -> Fp(s,e)]: absolute value *)
+    | Neg  of int * int
+    (** [Fp_neg(s,e): Fp(s,e) -> Fp(s,e)]: negation *)
+    | Add  of int * int
+    (** [Fp_add(s,e): RoundingMode -> Fp(s,e) -> Fp(s,e) -> Fp(s,e)]: addition *)
+    | Sub  of int * int
+    (** [Fp_sub(s,e): RoundingMode -> Fp(s,e) -> Fp(s,e) -> Fp(s,e)]: subtraction *)
+    | Mul  of int * int
+    (** [Fp_mul(s,e): RoundingMode -> Fp(s,e) -> Fp(s,e) -> Fp(s,e)]: multiplication *)
+    | Div  of int * int
+    (** [Fp_div(s,e): RoundingMode -> Fp(s,e) -> Fp(s,e) -> Fp(s,e)]: division *)
+    | Fma  of int * int
+    (** [Fp_fma(s,e): RoundingMode -> Fp(s,e) -> Fp(s,e)]: fuse multiply add *)
+    | Sqrt  of int * int
+    (** [Fp_sqrt(s,e): RoundingMode -> Fp(s,e) -> Fp(s,e)]: square root *)
+    | Rem  of int * int
+    (** [Fp_rem(s,e): Fp(s,e) -> Fp(s,e) -> Fp(s,e)]: remainder *)
+    | RoundToIntegral  of int * int
+    (** [Fp_roundToIntegral(s,e): RoundingMode -> Fp(s,e) -> Fp(s,e)]: round to integral *)
+    | Min  of int * int
+    (** [Fp_min(s,e): Fp(s,e) -> Fp(s,e) -> Fp(s,e)]: minimum *)
+    | Max  of int * int
+    (** [Fp_max(s,e): Fp(s,e) -> Fp(s,e) -> Fp(s,e)]: maximum *)
+    | Leq  of int * int
+    (** [Fp_leq(s,e): Fp(s,e) -> Fp(s,e) -> Prop.T]: IEEE less or equal *)
+    | Lt  of int * int
+    (** [Fp_lt(s,e): Fp(s,e) -> Fp(s,e) -> Prop.T]: IEEE less than *)
+    | Geq  of int * int
+    (** [Fp_geq(s,e): Fp(s,e) -> Fp(s,e) -> Prop.T]: IEEE greater or equal *)
+    | Gt  of int * int
+    (** [Fp_gt(s,e): Fp(s,e) -> Fp(s,e) -> Prop.T]: IEEE greater than *)
+    | Eq  of int * int
+    (** [Fp_eq(s,e): Fp(s,e) -> Fp(s,e) -> Prop.T]: IEEE equality *)
+    | IsNormal  of int * int
+    (** [Fp_isNormal(s,e): Fp(s,e) -> Prop.T]: test if it is a normal floating point *)
+    | IsSubnormal  of int * int
+    (** [Fp_isSubnormal(s,e): Fp(s,e) -> Prop.T]: test if it is a subnormal floating point *)
+    | IsZero  of int * int
+    (** [Fp_isZero(s,e): Fp(s,e) -> Prop.T]: test if it is a zero *)
+    | IsInfinite  of int * int
+    (** [Fp_isInfinite(s,e): Fp(s,e) -> Prop.T]: test if it is an infinite *)
+    | IsNaN  of int * int
+    (** [Fp_isNaN(s,e): Fp(s,e) -> Prop.T]: test if it is Not a Number *)
+    | IsNegative  of int * int
+    (** [Fp_isNegative(s,e): Fp(s,e) -> Prop.T]: test if it is negative *)
+    | IsPositive  of int * int
+    (** [Fp_isPositive(s,e): Fp(s,e) -> Prop.T]: test if it is positive *)
+    | Ieee_format_to_fp of int * int
+    (** [Ieee_format_to_fp(s,e): Bv(s+e) -> Fp(s,e)]: Convert from IEEE interchange format *)
+    | To_fp of int * int * int * int
+    (** [Fp_to_fp(s1,e1,s2,e2): RoundingMode -> Fp(s1,e1) -> Fp(s2,e2)]:
+        Convert from another floating point format *)
+    | Of_real of int * int
+    (** [Real_to_fp(s,e): RoundingMode -> Real -> Fp(s,e)]: Convert from a real *)
+    | Of_sbv of int * int * int
+    (** [Sbv_to_fp(m,s,e): RoundingMode -> Bitv.T(m) -> Fp(s,e)]: Convert from a signed integer *)
+    | Of_ubv of int * int * int
+    (** [Ubv_to_fp(m,s,e): RoundingMode -> Bitv.T(m) -> Fp(s,e)]: Convert from a unsigned integer *)
+    | To_ubv of int * int * int
+    (** [To_ubv(s,e,m): RoundingMode -> Fp(s,e) -> Bitv.T(m)]: Convert to an unsigned integer *)
+    | To_sbv of int * int * int
+    (** [To_ubv(s,e,m): RoundingMode -> Fp(s,e) -> Bitv.T(m)]: Convert to an signed integer *)
+    | To_real of int * int
+    (** [To_real(s,e): Fp(s,e) -> Real]: Convert to real *)
+end
+
+type 'a t += Float of 'a Float.t
 
 
 (** {2 String and Regexp Builtins} *)
 (*  ************************************************************************* *)
 
-type _ t +=
-  | String
-  (** [String: ttype]: type constructor for strings. *)
-  | Str of string
-  (** [Str s: String]: string literals. *)
-  | Str_length
-  (** [Str_length: String -> Int]: string length. *)
-  | Str_at
-  (** [Str_at: String -> Int -> String]:
-      Singleton string containing a character at given position
-      or empty string when position is out of range.
-      The leftmost position is 0. *)
-  | Str_to_code
-  (** [Str_to_code: String -> Int]:
-      [Str_to_code s] is the code point of the only character of s,
-      if s is a singleton string; otherwise, it is -1. *)
-  | Str_of_code
-  (** [Str_of_code: Int -> String]:
-      [Str_of_code n] is the singleton string whose only character is
-      code point n if n is in the range [0, 196607]; otherwise, it is the
-      empty string. *)
-  | Str_is_digit
-  (** [Str_is_digit: String -> Prop]: Digit check
-      [Str.is_digit s] is true iff s consists of a single character which is
-      a decimal digit, that is, a code point in the range 0x0030 ... 0x0039. *)
-  | Str_to_int
-  (** [Str_to_int: String -> Int]: Conversion to integers
-      [Str.to_int s] with s consisting of digits (in the sense of str.is_digit)
-      evaluates to the positive integer denoted by s when seen as a number in
-      base 10 (possibly with leading zeros).
-      It evaluates to -1 if s is empty or contains non-digits. *)
-  | Str_of_int
-  (** [Str_of_int : Int -> String]: Conversion from integers.
-      [Str.from_int n] with n non-negative is the corresponding string in
-      decimal notation, with no leading zeros. If n < 0, it is the empty string. *)
-  | Str_concat
-  (** [Str_concat: String -> String -> String]: string concatenation. *)
-  | Str_sub
-  (** [Str_sub: String -> Int -> Int -> String]:
-      [Str_sub s i n] evaluates to the longest (unscattered) substring
-      of s of length at most n starting at position i.
-      It evaluates to the empty string if n is negative or i is not in
-      the interval [0,l-1] where l is the length of s. *)
-  | Str_index_of
-  (** [Str_index_of: String -> String -> Int -> Int]:
-      Index of first occurrence of second string in first one starting at
-      the position specified by the third argument.
-      [Str_index_of s t i], with 0 <= i <= |s| is the position of the first
-      occurrence of t in s at or after position i, if any.
-      Otherwise, it is -1. Note that the result is i whenever i is within
-      the range [0, |s|] and t is empty. *)
-  | Str_replace
-  (** [Str_replace: String -> String -> String -> String]: Replace
-      [Str_replace s t t'] is the string obtained by replacing the first
-      occurrence of t in s, if any, by t'. Note that if t is empty, the
-      result is to prepend t' to s; also, if t does not occur in s then
-      the result is s. *)
-  | Str_replace_all
-  (** [Str_replace_all: String -> String -> String -> String]:
-      [Str_replace_all s t t’] is s if t is the empty string. Otherwise, it
-      is the string obtained from s by replacing all occurrences of t in s
-      by t’, starting with the first occurrence and proceeding in
-      left-to-right order. *)
-  | Str_replace_re
-  (** [Str_replace_re: String -> String_RegLan -> String -> String]:
-      [Str_replace_re s r t] is the string obtained by replacing the
-      shortest leftmost non-empty match of r in s, if any, by t.
-      Note that if t is empty, the result is to prepend t to s. *)
-  | Str_replace_re_all
-  (** [Str_replace_re_all: String -> String_RegLan -> String -> String]:
-      [Str_replace_re_all s r t] is the string obtained by replacing,
-      left-to right, each shortest *non-empty* match of r in s by t. *)
-  | Str_is_prefix
-  (** [Str_is_prefix: String -> String -> Prop]: Prefix check
-      [Str_is_prefix s t] is true iff s is a prefix of t. *)
-  | Str_is_suffix
-  (** [Str_is_suffix: String -> String -> Prop]: Suffix check
-      [Str_is_suffix s t] is true iff s is a suffix of t. *)
-  | Str_contains
-  (** [Str_contains: String -> String -> Prop]: Inclusion check
-      [Str_contains s t] is true iff s contains t. *)
-  | Str_lexicographic_strict
-  (** [Str_lexicographic_strict: String -> String -> Prop]:
-      lexicographic ordering (strict). *)
-  | Str_lexicographic_large
-  (** [Str_lexicographic_large: String -> String -> Prop]:
-      reflexive closure of the lexicographic ordering. *)
-  | Str_in_re
-  (** [Str_in_re: String -> String_RegLan -> Prop]: set membership. *)
+module Str : sig
 
-(* String Regular languages *)
-type _ t +=
-  | String_RegLan
-  (** [String_RegLan: ttype]:
-      type constructor for Regular languages over strings. *)
-  | Re_empty
-  (** [Re_empty: String_RegLan]:
-      the empty language. *)
-  | Re_all
-  (** [Re_all: String_RegLan]:
-      the language of all strings. *)
-  | Re_allchar
-  (** [Re_allchar: String_RegLan]:
-      the language of all singleton strings. *)
-  | Re_of_string
-  (** [Re_of_string: String -> String_RegLan]:
-      the singleton language with a single string. *)
-  | Re_range
-  (** [Re_range: String -> String -> String_RegLan]: Language range
-      [Re_range s1 s2] is the set of all *singleton* strings [s] such that
-      [Str_lexicographic_large s1 s s2] provided [s1] and [s1] are singleton.
-      Otherwise, it is the empty language. *)
-  | Re_concat
-  (** [Re_concat: String_RegLan -> String_RegLan -> String_RegLan]:
-      language concatenation. *)
-  | Re_union
-  (** [Re_union: String_RegLan -> String_RegLan -> String_RegLan]:
-      language union. *)
-  | Re_inter
-  (** [Re_inter: String_RegLan -> String_RegLan -> String_RegLan]:
-      language intersection. *)
-  | Re_star
-  (** [Re_star: String_RegLan -> String_RegLan]: Kleen star. *)
-  | Re_cross
-  (** [Re_cross: String_RegLan -> String_RegLan]: Kleen cross. *)
-  | Re_complement
-  (** [Re_complement: String_RegLan -> String_RegLan]: language complement. *)
-  | Re_diff
-  (** [Re_diff: String_RegLan -> String_RegLan -> String_RegLan]:
-      language difference. *)
-  | Re_option
-  (** [Re_option: String_RegLan -> String_RegLan]: language option
-      [Re_option e] abbreviates [Re_union e (Str_to_re "")]. *)
-  | Re_power of int
-  (** [Re_power(n): String_RegLan -> String_RegLan]:
-      [Re_power(n) e] is the nth power of e:
-      - [Re_power(0) e] is [Str_to_re ""]
-      - [Re_power(n+1) e] is [Re_concat e (Re_power(n) e)] *)
-  | Re_loop of int * int
-  (** [Re_loop(n1,n2): String_RegLan -> String_RegLan]:
-      Defined as:
-      - [Re_loop(n₁, n₂) e] is [Re_empty]                   if n₁ > n₂
-      - [Re_loop(n₁, n₂) e] is [Re_power(n₁) e]             if n₁ = n₂
-      - [Re_loop(n₁, n₂) e] is
-        [Re_union ((Re_power(n₁) e) ... (Re_power(n₂) e))]  if n₁ < n₂
-  *)
+  type _ t =
+    | T
+    (** [String: ttype]: type constructor for strings. *)
+    | Raw of string
+    (** [Str s: String]: string literals. *)
+    | Length
+    (** [Str_length: String -> Int]: string length. *)
+    | At
+    (** [Str_at: String -> Int -> String]:
+        Singleton string containing a character at given position
+        or empty string when position is out of range.
+        The leftmost position is 0. *)
+    | To_code
+    (** [Str_to_code: String -> Int]:
+        [Str_to_code s] is the code point of the only character of s,
+        if s is a singleton string; otherwise, it is -1. *)
+    | Of_code
+    (** [Str_of_code: Int -> String]:
+        [Str_of_code n] is the singleton string whose only character is
+        code point n if n is in the range [0, 196607]; otherwise, it is the
+        empty string. *)
+    | Is_digit
+    (** [Str_is_digit: String -> Prop.T]: Digit check
+        [Str.is_digit s] is true iff s consists of a single character which is
+        a decimal digit, that is, a code point in the range 0x0030 ... 0x0039. *)
+    | To_int
+    (** [Str_to_int: String -> Int]: Conversion to integers
+        [Str.to_int s] with s consisting of digits (in the sense of str.is_digit)
+        evaluates to the positive integer denoted by s when seen as a number in
+        base 10 (possibly with leading zeros).
+        It evaluates to -1 if s is empty or contains non-digits. *)
+    | Of_int
+    (** [Str_of_int : Int -> String]: Conversion from integers.
+        [Str.from_int n] with n non-negative is the corresponding string in
+        decimal notation, with no leading zeros. If n < 0, it is the empty string. *)
+    | Concat
+    (** [Str_concat: String -> String -> String]: string concatenation. *)
+    | Sub
+    (** [Str_sub: String -> Int -> Int -> String]:
+        [Str_sub s i n] evaluates to the longest (unscattered) substring
+        of s of length at most n starting at position i.
+        It evaluates to the empty string if n is negative or i is not in
+        the interval [0,l-1] where l is the length of s. *)
+    | Index_of
+    (** [Str_index_of: String -> String -> Int -> Int]:
+        Index of first occurrence of second string in first one starting at
+        the position specified by the third argument.
+        [Str_index_of s t i], with 0 <= i <= |s| is the position of the first
+        occurrence of t in s at or after position i, if any.
+        Otherwise, it is -1. Note that the result is i whenever i is within
+        the range [0, |s|] and t is empty. *)
+    | Replace
+    (** [Str_replace: String -> String -> String -> String]: Replace
+        [Str_replace s t t'] is the string obtained by replacing the first
+        occurrence of t in s, if any, by t'. Note that if t is empty, the
+        result is to prepend t' to s; also, if t does not occur in s then
+        the result is s. *)
+    | Replace_all
+    (** [Str_replace_all: String -> String -> String -> String]:
+        [Str_replace_all s t t’] is s if t is the empty string. Otherwise, it
+        is the string obtained from s by replacing all occurrences of t in s
+        by t’, starting with the first occurrence and proceeding in
+        left-to-right order. *)
+    | Replace_re
+    (** [Str_replace_re: String -> String_RegLan -> String -> String]:
+        [Str_replace_re s r t] is the string obtained by replacing the
+        shortest leftmost non-empty match of r in s, if any, by t.
+        Note that if t is empty, the result is to prepend t to s. *)
+    | Replace_re_all
+    (** [Str_replace_re_all: String -> String_RegLan -> String -> String]:
+        [Str_replace_re_all s r t] is the string obtained by replacing,
+        left-to right, each shortest *non-empty* match of r in s by t. *)
+    | Is_prefix
+    (** [Str_is_prefix: String -> String -> Prop.T]: Prefix check
+        [Str_is_prefix s t] is true iff s is a prefix of t. *)
+    | Is_suffix
+    (** [Str_is_suffix: String -> String -> Prop.T]: Suffix check
+        [Str_is_suffix s t] is true iff s is a suffix of t. *)
+    | Contains
+    (** [Str_contains: String -> String -> Prop.T]: Inclusion check
+        [Str_contains s t] is true iff s contains t. *)
+    | Lexicographic_strict
+    (** [Str_lexicographic_strict: String -> String -> Prop.T]:
+        lexicographic ordering (strict). *)
+    | Lexicographic_large
+    (** [Str_lexicographic_large: String -> String -> Prop.T]:
+        reflexive closure of the lexicographic ordering. *)
+    | In_re
+    (** [Str_in_re: String -> String_RegLan -> Prop.T]: set membership. *)
+
+  module RegLan : sig
+    (* String Regular languages *)
+    type _ t =
+      | T
+      (** [String_RegLan: ttype]:
+          type constructor for Regular languages over strings. *)
+      | Empty
+      (** [Re_empty: String_RegLan]:
+          the empty language. *)
+      | All
+      (** [Re_all: String_RegLan]:
+          the language of all strings. *)
+      | Allchar
+      (** [Re_allchar: String_RegLan]:
+          the language of all singleton strings. *)
+      | Of_string
+      (** [Re_of_string: String -> String_RegLan]:
+          the singleton language with a single string. *)
+      | Range
+      (** [Re_range: String -> String -> String_RegLan]: Language range
+          [Re_range s1 s2] is the set of all *singleton* strings [s] such that
+          [Str_lexicographic_large s1 s s2] provided [s1] and [s1] are singleton.
+          Otherwise, it is the empty language. *)
+      | Concat
+      (** [Re_concat: String_RegLan -> String_RegLan -> String_RegLan]:
+          language concatenation. *)
+      | Union
+      (** [Re_union: String_RegLan -> String_RegLan -> String_RegLan]:
+          language union. *)
+      | Inter
+      (** [Re_inter: String_RegLan -> String_RegLan -> String_RegLan]:
+          language intersection. *)
+      | Star
+      (** [Re_star: String_RegLan -> String_RegLan]: Kleen star. *)
+      | Cross
+      (** [Re_cross: String_RegLan -> String_RegLan]: Kleen cross. *)
+      | Complement
+      (** [Re_complement: String_RegLan -> String_RegLan]: language complement. *)
+      | Diff
+      (** [Re_diff: String_RegLan -> String_RegLan -> String_RegLan]:
+          language difference. *)
+      | Option
+      (** [Re_option: String_RegLan -> String_RegLan]: language option
+          [Re_option e] abbreviates [Re_union e (Str_to_re "")]. *)
+      | Power of int
+      (** [Re_power(n): String_RegLan -> String_RegLan]:
+          [Re_power(n) e] is the nth power of e:
+          - [Re_power(0) e] is [Str_to_re ""]
+          - [Re_power(n+1) e] is [Re_concat e (Re_power(n) e)] *)
+      | Loop of int * int
+      (** [Re_loop(n1,n2): String_RegLan -> String_RegLan]:
+          Defined as:
+          - [Re_loop(n₁, n₂) e] is [Re_empty]                   if n₁ > n₂
+          - [Re_loop(n₁, n₂) e] is [Re_power(n₁) e]             if n₁ = n₂
+          - [Re_loop(n₁, n₂) e] is
+            [Re_union ((Re_power(n₁) e) ... (Re_power(n₂) e))]  if n₁ < n₂
+      *)
+  end
+
+end
+
+type 'a t +=
+  | Str of 'a Str.t
+  (** String builtins *)
+  | Regexp of 'a Str.RegLan.t
+  (** String Regular language builtins, aka regexps. *)
 

--- a/src/standard/expr.ml
+++ b/src/standard/expr.ml
@@ -1003,13 +1003,13 @@ module Ty = struct
     let array = mk' ~builtin:(Builtin.Array T) "array" 2
     let map = mk' ~pos:Infix ~name:"~~>" ~builtin:(Builtin.Map T) "map" 2
     let bitv =
-      with_cache (fun i ->
-          if i <= 0 then raise (Non_positive_bitvector_size i)
-          else mk' ~builtin:(Builtin.Bitv (T i)) (Format.asprintf "Bitv_%d" i) 0
+      with_cache (fun n ->
+          if n <= 0 then raise (Non_positive_bitvector_size n)
+          else mk' ~builtin:(Builtin.Bitv (T {n})) (Format.asprintf "Bitv_%d" n) 0
         )
     let float =
       with_cache (fun (e,s) ->
-          mk' ~builtin:(Builtin.Float (T (e,s))) (Format.asprintf "FloatingPoint_%d_%d" e s) 0
+          mk' ~builtin:(Builtin.Float (T {e;s})) (Format.asprintf "FloatingPoint_%d_%d" e s) 0
         )
     let roundingMode = mk' ~builtin:(Builtin.Float RoundingMode) "RoundingMode" 0
   end
@@ -1297,8 +1297,8 @@ module Ty = struct
         | Builtin.Arith Int -> `Int
         | Builtin.Arith Rat -> `Rat
         | Builtin.Arith Real -> `Real
-        | Builtin.Bitv T i -> `Bitv i
-        | Builtin.Float T (e, s) -> `Float (e, s)
+        | Builtin.Bitv T { n } -> `Bitv n
+        | Builtin.Float T { e; s } -> `Float (e, s)
         | Builtin.Map T -> begin match l with
             | [param; ret] -> `Map (param, ret)
             | _ -> assert false (* not possible *)
@@ -2375,149 +2375,149 @@ module Term = struct
 
       let not =
         with_cache (fun n ->
-            mk' ~builtin:(Builtin.Bitv (Not n)) "bvnot" [] [Ty.bitv n] (Ty.bitv n)
+            mk' ~builtin:(Builtin.Bitv (Not {n})) "bvnot" [] [Ty.bitv n] (Ty.bitv n)
           )
 
       let and_ =
         with_cache (fun n ->
-            mk' ~builtin:(Builtin.Bitv (And n)) "bvand" []
+            mk' ~builtin:(Builtin.Bitv (And {n})) "bvand" []
               [Ty.bitv n; Ty.bitv n] (Ty.bitv n)
           )
 
       let or_ =
         with_cache (fun n ->
-            mk' ~builtin:(Builtin.Bitv (Or n)) "bvor" []
+            mk' ~builtin:(Builtin.Bitv (Or {n})) "bvor" []
               [Ty.bitv n; Ty.bitv n] (Ty.bitv n)
           )
 
       let nand =
         with_cache (fun n ->
-            mk' ~builtin:(Builtin.Bitv (Nand n)) "bvnand" []
+            mk' ~builtin:(Builtin.Bitv (Nand {n})) "bvnand" []
               [Ty.bitv n; Ty.bitv n] (Ty.bitv n)
           )
 
       let nor =
         with_cache (fun n ->
-            mk' ~builtin:(Builtin.Bitv (Nor n)) "bvnor" []
+            mk' ~builtin:(Builtin.Bitv (Nor {n})) "bvnor" []
               [Ty.bitv n; Ty.bitv n] (Ty.bitv n)
           )
 
       let xor =
         with_cache (fun n ->
-            mk' ~builtin:(Builtin.Bitv (Xor n)) "bvxor" []
+            mk' ~builtin:(Builtin.Bitv (Xor {n})) "bvxor" []
               [Ty.bitv n; Ty.bitv n] (Ty.bitv n)
           )
 
       let xnor =
         with_cache (fun n ->
-            mk' ~builtin:(Builtin.Bitv (Xnor n)) "bvxnor" []
+            mk' ~builtin:(Builtin.Bitv (Xnor {n})) "bvxnor" []
               [Ty.bitv n; Ty.bitv n] (Ty.bitv n)
           )
 
       let comp =
         with_cache (fun n ->
-            mk' ~builtin:(Builtin.Bitv (Comp n)) "bvcomp" []
+            mk' ~builtin:(Builtin.Bitv (Comp {n})) "bvcomp" []
               [Ty.bitv n; Ty.bitv n] (Ty.bitv 1)
           )
 
       let neg =
         with_cache (fun n ->
-            mk' ~builtin:(Builtin.Bitv (Neg n)) "bvneg" [] [Ty.bitv n] (Ty.bitv n)
+            mk' ~builtin:(Builtin.Bitv (Neg {n})) "bvneg" [] [Ty.bitv n] (Ty.bitv n)
           )
 
       let add =
         with_cache (fun n ->
-            mk' ~builtin:(Builtin.Bitv (Add n)) "bvadd" [] [Ty.bitv n; Ty.bitv n] (Ty.bitv n)
+            mk' ~builtin:(Builtin.Bitv (Add {n})) "bvadd" [] [Ty.bitv n; Ty.bitv n] (Ty.bitv n)
           )
 
       let sub =
         with_cache (fun n ->
-            mk' ~builtin:(Builtin.Bitv (Sub n)) "bvsub" [] [Ty.bitv n; Ty.bitv n] (Ty.bitv n)
+            mk' ~builtin:(Builtin.Bitv (Sub {n})) "bvsub" [] [Ty.bitv n; Ty.bitv n] (Ty.bitv n)
           )
 
       let mul =
         with_cache (fun n ->
-            mk' ~builtin:(Builtin.Bitv (Mul n)) "bvmul" [] [Ty.bitv n; Ty.bitv n] (Ty.bitv n)
+            mk' ~builtin:(Builtin.Bitv (Mul {n})) "bvmul" [] [Ty.bitv n; Ty.bitv n] (Ty.bitv n)
           )
 
       let udiv =
         with_cache (fun n ->
-            mk' ~builtin:(Builtin.Bitv (Udiv n)) "bvudiv" [] [Ty.bitv n; Ty.bitv n] (Ty.bitv n)
+            mk' ~builtin:(Builtin.Bitv (Udiv {n})) "bvudiv" [] [Ty.bitv n; Ty.bitv n] (Ty.bitv n)
           )
 
       let urem =
         with_cache (fun n ->
-            mk' ~builtin:(Builtin.Bitv (Urem n)) "bvurem" [] [Ty.bitv n; Ty.bitv n] (Ty.bitv n)
+            mk' ~builtin:(Builtin.Bitv (Urem {n})) "bvurem" [] [Ty.bitv n; Ty.bitv n] (Ty.bitv n)
           )
 
       let sdiv =
         with_cache (fun n ->
-            mk' ~builtin:(Builtin.Bitv (Sdiv n)) "bvsdiv" [] [Ty.bitv n; Ty.bitv n] (Ty.bitv n)
+            mk' ~builtin:(Builtin.Bitv (Sdiv {n})) "bvsdiv" [] [Ty.bitv n; Ty.bitv n] (Ty.bitv n)
           )
 
       let srem =
         with_cache (fun n ->
-            mk' ~builtin:(Builtin.Bitv (Srem n)) "bvsrem" [] [Ty.bitv n; Ty.bitv n] (Ty.bitv n)
+            mk' ~builtin:(Builtin.Bitv (Srem {n})) "bvsrem" [] [Ty.bitv n; Ty.bitv n] (Ty.bitv n)
           )
 
       let smod =
         with_cache (fun n ->
-            mk' ~builtin:(Builtin.Bitv (Smod n)) "bvsmod" [] [Ty.bitv n; Ty.bitv n] (Ty.bitv n)
+            mk' ~builtin:(Builtin.Bitv (Smod {n})) "bvsmod" [] [Ty.bitv n; Ty.bitv n] (Ty.bitv n)
           )
 
       let shl =
         with_cache (fun n ->
-            mk' ~builtin:(Builtin.Bitv (Shl n)) "bvshl" [] [Ty.bitv n; Ty.bitv n] (Ty.bitv n)
+            mk' ~builtin:(Builtin.Bitv (Shl {n})) "bvshl" [] [Ty.bitv n; Ty.bitv n] (Ty.bitv n)
           )
 
       let lshr =
         with_cache (fun n ->
-            mk' ~builtin:(Builtin.Bitv (Lshr n)) "bvlshr" [] [Ty.bitv n; Ty.bitv n] (Ty.bitv n)
+            mk' ~builtin:(Builtin.Bitv (Lshr {n})) "bvlshr" [] [Ty.bitv n; Ty.bitv n] (Ty.bitv n)
           )
 
       let ashr =
         with_cache (fun n ->
-            mk' ~builtin:(Builtin.Bitv (Ashr n)) "bvashr" [] [Ty.bitv n; Ty.bitv n] (Ty.bitv n)
+            mk' ~builtin:(Builtin.Bitv (Ashr {n})) "bvashr" [] [Ty.bitv n; Ty.bitv n] (Ty.bitv n)
           )
 
       let ult =
         with_cache (fun n ->
-            mk' ~builtin:(Builtin.Bitv (Ult n)) "bvult" [] [Ty.bitv n; Ty.bitv n] Ty.prop
+            mk' ~builtin:(Builtin.Bitv (Ult {n})) "bvult" [] [Ty.bitv n; Ty.bitv n] Ty.prop
           )
 
       let ule =
         with_cache (fun n ->
-            mk' ~builtin:(Builtin.Bitv (Ule n)) "bvule" [] [Ty.bitv n; Ty.bitv n] Ty.prop
+            mk' ~builtin:(Builtin.Bitv (Ule {n})) "bvule" [] [Ty.bitv n; Ty.bitv n] Ty.prop
           )
 
       let ugt =
         with_cache (fun n ->
-            mk' ~builtin:(Builtin.Bitv (Ugt n)) "bvugt" [] [Ty.bitv n; Ty.bitv n] Ty.prop
+            mk' ~builtin:(Builtin.Bitv (Ugt {n})) "bvugt" [] [Ty.bitv n; Ty.bitv n] Ty.prop
           )
 
       let uge =
         with_cache (fun n ->
-            mk' ~builtin:(Builtin.Bitv (Uge n)) "bvsge" [] [Ty.bitv n; Ty.bitv n] Ty.prop
+            mk' ~builtin:(Builtin.Bitv (Uge {n})) "bvsge" [] [Ty.bitv n; Ty.bitv n] Ty.prop
           )
 
       let slt =
         with_cache (fun n ->
-            mk' ~builtin:(Builtin.Bitv (Slt n)) "bvslt" [] [Ty.bitv n; Ty.bitv n] Ty.prop
+            mk' ~builtin:(Builtin.Bitv (Slt {n})) "bvslt" [] [Ty.bitv n; Ty.bitv n] Ty.prop
           )
 
       let sle =
         with_cache (fun n ->
-            mk' ~builtin:(Builtin.Bitv (Sle n)) "bvsle" [] [Ty.bitv n; Ty.bitv n] Ty.prop
+            mk' ~builtin:(Builtin.Bitv (Sle {n})) "bvsle" [] [Ty.bitv n; Ty.bitv n] Ty.prop
           )
 
       let sgt =
         with_cache (fun n ->
-            mk' ~builtin:(Builtin.Bitv (Sgt n)) "bvsgt" [] [Ty.bitv n; Ty.bitv n] Ty.prop
+            mk' ~builtin:(Builtin.Bitv (Sgt {n})) "bvsgt" [] [Ty.bitv n; Ty.bitv n] Ty.prop
           )
 
       let sge =
         with_cache (fun n ->
-            mk' ~builtin:(Builtin.Bitv (Sge n)) "bvsge" [] [Ty.bitv n; Ty.bitv n] Ty.prop
+            mk' ~builtin:(Builtin.Bitv (Sge {n})) "bvsge" [] [Ty.bitv n; Ty.bitv n] Ty.prop
           )
 
       let nego =
@@ -2559,7 +2559,7 @@ module Term = struct
 
       let fp =
         with_cache (fun (e, s) ->
-            mk' ~builtin:(Builtin.Float (Fp (e, s))) "fp" []
+            mk' ~builtin:(Builtin.Float (Fp { e; s })) "fp" []
               [Ty.bitv 1; Ty.bitv e; Ty.bitv (s-1)] (Ty.float e s)
           )
 
@@ -2596,122 +2596,122 @@ module Term = struct
 
       let plus_infinity =
         fp_gen_fun ~args:0 "plus_infinity"
-          (fun (e,s) -> Plus_infinity (e,s))
+          (fun (e,s) -> Plus_infinity {e;s})
       let minus_infinity =
         fp_gen_fun ~args:0 "minus_infinity"
-          (fun (e,s) -> Minus_infinity (e,s))
+          (fun (e,s) -> Minus_infinity {e;s})
       let plus_zero =
         fp_gen_fun ~args:0 "plus_zero"
-          (fun (e,s) -> Plus_zero (e,s))
+          (fun (e,s) -> Plus_zero {e;s})
       let minus_zero =
         fp_gen_fun ~args:0 "minus_zero"
-          (fun (e,s) -> Minus_zero (e,s))
+          (fun (e,s) -> Minus_zero {e;s})
       let nan =
         fp_gen_fun ~args:0 "nan"
-          (fun (e,s) -> NaN (e,s))
+          (fun (e,s) -> NaN {e;s})
       let abs =
         fp_gen_fun ~args:1 "fp.abs"
-          (fun (e,s) -> Abs (e,s))
+          (fun (e,s) -> Abs {e;s})
       let neg =
         fp_gen_fun ~args:1 "fp.neg"
-          (fun (e,s) -> Neg (e,s))
+          (fun (e,s) -> Neg {e;s})
       let add =
         fp_gen_fun ~args:2 ~rm:() "fp.add"
-          (fun (e,s) -> Add (e,s))
+          (fun (e,s) -> Add {e;s})
       let sub =
         fp_gen_fun ~args:2 ~rm:() "fp.sub"
-          (fun (e,s) -> Sub (e,s))
+          (fun (e,s) -> Sub {e;s})
       let mul =
         fp_gen_fun ~args:2 ~rm:() "fp.mul"
-          (fun (e,s) -> Mul (e,s))
+          (fun (e,s) -> Mul {e;s})
       let div =
         fp_gen_fun ~args:2 ~rm:() "fp.div"
-          (fun (e,s) -> Div (e,s))
+          (fun (e,s) -> Div {e;s})
       let fma =
         fp_gen_fun ~args:3 ~rm:() "fp.fma"
-          (fun (e,s) -> Fma (e,s))
+          (fun (e,s) -> Fma {e;s})
       let sqrt =
         fp_gen_fun ~args:1 ~rm:() "fp.sqrt"
-          (fun (e,s) -> Sqrt (e,s))
+          (fun (e,s) -> Sqrt {e;s})
       let rem =
         fp_gen_fun ~args:2 "fp.rem"
-          (fun (e,s) -> Rem (e,s))
+          (fun (e,s) -> Rem {e;s})
       let roundToIntegral =
         fp_gen_fun ~args:1 ~rm:() "fp.roundToIntegral"
-          (fun (e,s) -> RoundToIntegral (e,s))
+          (fun (e,s) -> RoundToIntegral {e;s})
       let min =
         fp_gen_fun ~args:2 "fp.min"
-          (fun (e,s) -> Min (e,s))
+          (fun (e,s) -> Min {e;s})
       let max =
         fp_gen_fun ~args:2 "fp.max"
-          (fun (e,s) -> Max (e,s))
+          (fun (e,s) -> Max {e;s})
       let leq =
         fp_gen_fun ~args:2 ~res:Ty.prop "fp.leq"
-          (fun (e,s) -> Leq (e,s))
+          (fun (e,s) -> Leq {e;s})
       let lt =
         fp_gen_fun ~args:2 ~res:Ty.prop "fp.lt"
-          (fun (e,s) -> Lt (e,s))
+          (fun (e,s) -> Lt {e;s})
       let geq =
         fp_gen_fun ~args:2 ~res:Ty.prop "fp.geq"
-          (fun (e,s) -> Geq (e,s))
+          (fun (e,s) -> Geq {e;s})
       let gt =
         fp_gen_fun ~args:2 ~res:Ty.prop "fp.gt"
-          (fun (e,s) -> Gt (e,s))
+          (fun (e,s) -> Gt {e;s})
       let eq =
         fp_gen_fun ~args:2 ~res:Ty.prop "fp.eq"
-          (fun (e,s) -> Eq (e,s))
+          (fun (e,s) -> Eq {e;s})
       let isNormal =
         fp_gen_fun ~args:1 ~res:Ty.prop "fp.isnormal"
-          (fun (e,s) -> IsNormal (e,s))
+          (fun (e,s) -> IsNormal {e;s})
       let isSubnormal =
         fp_gen_fun ~args:1 ~res:Ty.prop "fp.issubnormal"
-          (fun (e,s) -> IsSubnormal (e,s))
+          (fun (e,s) -> IsSubnormal {e;s})
       let isZero =
         fp_gen_fun ~args:1 ~res:Ty.prop "fp.iszero"
-          (fun (e,s) -> IsZero (e,s))
+          (fun (e,s) -> IsZero {e;s})
       let isInfinite =
         fp_gen_fun ~args:1 ~res:Ty.prop "fp.isinfinite"
-          (fun (e,s) -> IsInfinite (e,s))
+          (fun (e,s) -> IsInfinite {e;s})
       let isNaN =
         fp_gen_fun ~args:1 ~res:Ty.prop "fp.isnan"
-          (fun (e,s) -> IsNaN (e,s))
+          (fun (e,s) -> IsNaN {e;s})
       let isNegative =
         fp_gen_fun ~args:1 ~res:Ty.prop "fp.isnegative"
-          (fun (e,s) -> IsNegative (e,s))
+          (fun (e,s) -> IsNegative {e;s})
       let isPositive =
         fp_gen_fun ~args:1 ~res:Ty.prop "fp.ispositive"
-          (fun (e,s) -> IsPositive (e,s))
+          (fun (e,s) -> IsPositive {e;s})
       let to_real =
         fp_gen_fun ~args:1 ~res:Ty.real "fp.to_real"
-          (fun (e,s) -> To_real (e,s))
+          (fun (e,s) -> To_real {e;s})
 
       let ieee_format_to_fp =
         with_cache (fun ((e,s) as es) ->
-            mk' ~builtin:(Builtin.Float (Ieee_format_to_fp (e,s))) "to_fp" [] [Ty.bitv (e+s)] (Ty.float' es)
+            mk' ~builtin:(Builtin.Float (Ieee_format_to_fp {e;s})) "to_fp" [] [Ty.bitv (e+s)] (Ty.float' es)
           )
       let to_fp =
         with_cache (fun (e1,s1,e2,s2) ->
-            mk' ~builtin:(Builtin.Float (To_fp (e1,s1,e2,s2))) "to_fp" [] [Ty.roundingMode;Ty.float e1 s1] (Ty.float e2 s2)
+            mk' ~builtin:(Builtin.Float (To_fp {e1;s1;e2;s2})) "to_fp" [] [Ty.roundingMode;Ty.float e1 s1] (Ty.float e2 s2)
           )
       let real_to_fp =
         with_cache (fun ((e,s) as es) ->
-            mk' ~builtin:(Builtin.Float (Of_real (e,s))) "to_fp" [] [Ty.roundingMode;Ty.real] (Ty.float' es)
+            mk' ~builtin:(Builtin.Float (Of_real {e;s})) "to_fp" [] [Ty.roundingMode;Ty.real] (Ty.float' es)
           )
       let sbv_to_fp =
-        with_cache (fun (bv,e,s) ->
-            mk' ~builtin:(Builtin.Float (Of_sbv (bv,e,s))) "to_fp" [] [Ty.roundingMode;Ty.bitv bv] (Ty.float e s)
+        with_cache (fun (m,e,s) ->
+            mk' ~builtin:(Builtin.Float (Of_sbv {m;e;s})) "to_fp" [] [Ty.roundingMode;Ty.bitv m] (Ty.float e s)
           )
       let ubv_to_fp =
-        with_cache (fun (bv,e,s) ->
-            mk' ~builtin:(Builtin.Float (Of_ubv (bv,e,s))) "to_fp" [] [Ty.roundingMode;Ty.bitv bv] (Ty.float e s)
+        with_cache (fun (m,e,s) ->
+            mk' ~builtin:(Builtin.Float (Of_ubv {m;e;s})) "to_fp" [] [Ty.roundingMode;Ty.bitv m] (Ty.float e s)
           )
       let to_ubv =
-        with_cache (fun (e,s,bv) ->
-            mk' ~builtin:(Builtin.Float (To_ubv (e,s,bv))) "fp.to_ubv" [] [Ty.roundingMode;Ty.float e s] (Ty.bitv bv)
+        with_cache (fun (e,s,m) ->
+            mk' ~builtin:(Builtin.Float (To_ubv {m;e;s})) "fp.to_ubv" [] [Ty.roundingMode;Ty.float e s] (Ty.bitv m)
           )
       let to_sbv =
-        with_cache (fun (e,s,bv) ->
-            mk' ~builtin:(Builtin.Float (To_sbv (e,s,bv))) "fp.to_sbv" [] [Ty.roundingMode;Ty.float e s] (Ty.bitv bv)
+        with_cache (fun (e,s,m) ->
+            mk' ~builtin:(Builtin.Float (To_sbv {m;e;s})) "fp.to_sbv" [] [Ty.roundingMode;Ty.float e s] (Ty.bitv m)
           )
 
     end
@@ -3491,7 +3491,7 @@ module Term = struct
   module Bitv = struct
     let match_bitv_type t =
       match Ty.descr (ty t) with
-      | TyApp ({ builtin = Builtin.Bitv T i; _ }, _) -> i
+      | TyApp ({ builtin = Builtin.Bitv T {n}; _ }, _) -> n
       | _ -> raise (Wrong_type (t, Ty.bitv 0))
 
     let mk s = apply_cst (Const.Bitv.bitv s) [] []
@@ -3671,7 +3671,7 @@ module Term = struct
     (* Floats *)
     let match_float_type t =
       match Ty.descr (ty t) with
-      | TyApp ({ builtin = Builtin.Float T (e,s); _ }, _) -> (e,s)
+      | TyApp ({ builtin = Builtin.Float T {e;s}; _ }, _) -> (e,s)
       | _ -> raise (Wrong_type (t, Ty.float 0 0))
 
     let fp sign exp significand =


### PR DESCRIPTION
This PR adds some hierarchy in the typed builtins. Previously all the builtins lived in a flat namespace, but now there is (most of the time) one extensible constructor builtin by theory, which wraps a dedicated (regular) type for the builtins of that theory. This brings a few benefits:
- We can have an exhaustivity check for functions operating on the primitives of one theory
- we can have more freedom in the naming of builtins, since we have different namespaces for the builtins of each theory
- This may result in a slight speedup, since matching on extensible variants is not very optimized

Note that this is a rather large breaking change, since it will likely require to update any pattern matching on builtins, but the translation should be rather mechanical. It is not completely mechanical because I took the opportunity to rename some builtins, taking advantage of the now different namespaces for builtins of different theories (and also to avoid repetitions like `| Builtin.Float Fp_foo -> ...`).

cc @bobot , in particular for the new names of primitives in the Float theory.