### PR TITLE
Add uutf as a dependency to dolmen

### DIFF
--- a/dolmen.opam
+++ b/dolmen.opam
@@ -17,6 +17,7 @@ depends: [
   "fmt" { >= "0.8.7" }
   "hmap" { >= "0.8.1" }
   "seq"
+  "uutf"
   "odoc" { with-doc }
   "qcheck" { with-test & >= "0.20" }
   "mdx" { with-test & >= "2.0.0" }


### PR DESCRIPTION
Uutf is used by string_unicode_map in dolmen.std, but it is only marked as a dependency of `dolmen_type`.