### PR TITLE
More precise error for lexing errors

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,11 @@ next
 
 - Add printers for the SMT-LIB format (PR#211)
 
+### Lexing
+
+- Better errors when a lexing error occurs inside of a quoted symbol
+  (PR#265)
+
 ### Typing
 
 - Add support for exponentiation in SMT-LIB2.7, as per the new

--- a/src/interface/lex.ml
+++ b/src/interface/lex.ml
@@ -8,7 +8,7 @@ module type S = sig
   type token
   (** The type of token produced by the lexer. *)
 
-  exception Error
+  exception Error of { context : string option; }
   (** The exception raised by the lexer when it cannot produce a token. *)
 
   val descr : token -> Tok.descr

--- a/src/interface/location.ml
+++ b/src/interface/location.ml
@@ -21,8 +21,10 @@ module type S = sig
   exception Uncaught of t * exn * Printexc.raw_backtrace
   (** The exception to be raised whenever an unexpected exception is raised during parsing. *)
 
-  exception Lexing_error of t * string
-  (** The exception to be raised when the lexer cannot parse the input. *)
+  exception Lexing_error of t * string option * string
+  (** The exception to be raised when the lexer cannot parse the input.
+      It contains (in order) the location, the context (if any), and then the string that
+      could not be lexed. *)
 
   exception Syntax_error of t * [
       | `Regular of Msg.t

--- a/src/languages/ae/lexer.mll
+++ b/src/languages/ae/lexer.mll
@@ -4,7 +4,7 @@
 (** {1 Alt-ergo Lexer} *)
 
 {
-  exception Error
+  exception Error of { context : string option; }
 
   module T = Dolmen_std.Tok
 
@@ -209,12 +209,12 @@ rule token newline = parse
   | "|->"                     { MAPS_TO }
   | "\""                      { parse_string newline (Buffer.create 1024) lexbuf }
   | eof                       { EOF }
-  | _ { raise Error }
+  | _ { raise (Error { context = None }) }
 
 and parse_comment newline = parse
   | "*)"    { () }
   | "(*"    { parse_comment newline lexbuf; parse_comment newline lexbuf }
-  | eof     { raise Error }
+  | eof     { raise (Error { context = Some "comment" }) }
   | _ as c  { if c = '\n' then newline lexbuf; parse_comment newline lexbuf }
 
 and parse_string newline str_buf = parse
@@ -224,7 +224,7 @@ and parse_string newline str_buf = parse
   | '\n'          { newline lexbuf;
                     Buffer.add_char str_buf '\n';
                     parse_string newline str_buf lexbuf }
-  | eof           { raise Error }
+  | eof           { raise (Error { context = Some "string" }) }
   | _ as c        { Buffer.add_char str_buf c;
                     parse_string newline str_buf lexbuf }
 

--- a/src/languages/dimacs/lexer.mll
+++ b/src/languages/dimacs/lexer.mll
@@ -2,7 +2,7 @@
 (* This file is free software, part of dolmen. See file "LICENSE" for more details. *)
 
 {
-  exception Error
+  exception Error of { context : string option; }
 
   module T = Dolmen_std.Tok
 
@@ -38,7 +38,7 @@ rule token newline = parse
   | [' ' '\t' '\r'] { token newline lexbuf }
   | number          { INT (int_of_string @@ Lexing.lexeme lexbuf) }
   | '\n'            { newline lexbuf; NEWLINE }
-  | _               { raise Error }
+  | _               { raise (Error { context = None }) }
 
 and comment newline = parse
   | eof   { EOF }

--- a/src/languages/icnf/lexer.mll
+++ b/src/languages/icnf/lexer.mll
@@ -2,7 +2,7 @@
 (* This file is free software, part of dolmen. See file "LICENSE" for more details. *)
 
 {
-  exception Error
+  exception Error of { context : string option; }
 
   module T = Dolmen_std.Tok
 
@@ -41,10 +41,10 @@ rule token newline = parse
   | [' ' '\t' '\r'] { token newline lexbuf }
   | number          { INT (int_of_string @@ Lexing.lexeme lexbuf) }
   | '\n'            { newline lexbuf; NEWLINE }
-  | _               { raise Error }
+  | _               { raise (Error { context = None }) }
 
 and comment newline = parse
   | '\n'            { newline lexbuf; token newline lexbuf }
   | printable_char  { comment newline lexbuf }
-  | _               { raise Error }
+  | _               { raise (Error { context = Some "comment" }) }
 

--- a/src/languages/smtlib2/poly/lexer.mll
+++ b/src/languages/smtlib2/poly/lexer.mll
@@ -4,7 +4,7 @@
 (** {1 Smtlib Lexer} *)
 
 {
-  exception Error
+  exception Error of { context : string option; }
 
   module T = Dolmen_std.Tok
   module M = Map.Make(String)
@@ -138,16 +138,6 @@
     try M.find s reserved_words
     with Not_found -> SYMBOL s
 
-  let quoted_symbol newline lexbuf s =
-    (* register the newlines in quoted symbols to maintain correct locations.*)
-    for i = 0 to (String.length s - 1) do
-      match s.[i] with
-      | '\n' -> newline lexbuf
-      | _ -> ()
-    done;
-    (* Quoted symbols allow to use reserved words as symbols *)
-    SYMBOL s
-
 }
 
 let white_space_char = ['\t' '\n' '\r' ' ']
@@ -194,10 +184,16 @@ rule token newline = parse
   | hexadecimal as s    { HEX s }
   | binary as s         { BIN s }
   | '"'                 { string newline (Buffer.create 42) lexbuf }
+  | '|'                 { quoted_symbol newline (Buffer.create 42) lexbuf }
   | keyword as s        { KEYWORD s }
-  | simple_symbol as s                  { symbol newline lexbuf s }
-  | '|' (quoted_symbol_char* as s) '|'  { quoted_symbol newline lexbuf s }
-  | _                                   { raise Error }
+  | simple_symbol as s  { symbol newline lexbuf s }
+  | _                   { raise (Error { context = None; }) }
+
+and quoted_symbol newline b = parse
+  | '|'                         { SYMBOL (Buffer.contents b) }
+  | quoted_symbol_char as c     { if c = '\n' then newline lexbuf;
+                                  Buffer.add_char b c; quoted_symbol newline b lexbuf }
+  | _                           { raise (Error { context = Some "quoted_symbol" }) }
 
 and string newline b = parse
   | '"' '"'             { Buffer.add_char b '"'; string newline b lexbuf }
@@ -205,7 +201,7 @@ and string newline b = parse
   | (printable_char | white_space_char) as c
     { if c = '\n' then newline lexbuf;
       Buffer.add_char b c; string newline b lexbuf }
-  | _                   { raise Error }
+  | _                   { raise (Error { context = Some "string" }) }
 
 (* these are there to simplify the task of printers, by allowing to
    check strings against some lexical categories *)

--- a/src/languages/smtlib2/v2.6/response/lexer.mll
+++ b/src/languages/smtlib2/v2.6/response/lexer.mll
@@ -4,7 +4,7 @@
 (** {1 Smtlib Lexer} *)
 
 {
-  exception Error
+  exception Error of { context : string option; }
 
   module T = Dolmen_std.Tok
   module M = Map.Make(String)
@@ -91,15 +91,6 @@
     try M.find s reserved_words
     with Not_found -> SYMBOL s
 
-  let quoted_symbol newline lexbuf s =
-    (* register the newlines in quoted symbols to maintain correct locations.*)
-    for i = 0 to (String.length s - 1) do
-      match s.[i] with
-      | '\n' -> newline lexbuf
-      | _ -> ()
-    done;
-    (* Quoted symbols allow to use reserved words as symbols *)
-    SYMBOL s
 }
 
 let white_space_char = ['\t' '\n' '\r' ' ']
@@ -143,10 +134,16 @@ rule token newline = parse
   | hexadecimal as s    { HEX s }
   | binary as s         { BIN s }
   | '"'                 { string newline (Buffer.create 42) lexbuf }
+  | '|'                 { quoted_symbol newline (Buffer.create 42) lexbuf }
   | keyword as s        { KEYWORD s }
-  | simple_symbol as s                  { symbol newline lexbuf s }
-  | '|' (quoted_symbol_char* as s) '|'  { quoted_symbol newline lexbuf s }
-  | _                                   { raise Error }
+  | simple_symbol as s  { symbol newline lexbuf s }
+  | _                   { raise (Error { context = None; }) }
+
+and quoted_symbol newline b = parse
+  | '|'                         { SYMBOL (Buffer.contents b) }
+  | quoted_symbol_char as c     { if c = '\n' then newline lexbuf;
+                                  Buffer.add_char b c; quoted_symbol newline b lexbuf }
+  | _                           { raise (Error { context = Some "quoted_symbol" }) }
 
 and string newline b = parse
   | '"' '"'             { Buffer.add_char b '"'; string newline b lexbuf }
@@ -154,5 +151,5 @@ and string newline b = parse
   | (printable_char | white_space_char) as c
     { if c = '\n' then newline lexbuf;
       Buffer.add_char b c; string newline b lexbuf }
-  | _                   { raise Error }
+  | _                   { raise (Error { context = Some "string" }) }
 

--- a/src/languages/smtlib2/v2.6/script/lexer.mll
+++ b/src/languages/smtlib2/v2.6/script/lexer.mll
@@ -4,7 +4,7 @@
 (** {1 Smtlib Lexer} *)
 
 {
-  exception Error
+  exception Error of { context : string option; }
 
   module T = Dolmen_std.Tok
   module M = Map.Make(String)
@@ -138,16 +138,6 @@
     try M.find s reserved_words
     with Not_found -> SYMBOL s
 
-  let quoted_symbol newline lexbuf s =
-    (* register the newlines in quoted symbols to maintain correct locations.*)
-    for i = 0 to (String.length s - 1) do
-      match s.[i] with
-      | '\n' -> newline lexbuf
-      | _ -> ()
-    done;
-    (* Quoted symbols allow to use reserved words as symbols *)
-    SYMBOL s
-
 }
 
 let white_space_char = ['\t' '\n' '\r' ' ']
@@ -194,10 +184,17 @@ rule token newline = parse
   | hexadecimal as s    { HEX s }
   | binary as s         { BIN s }
   | '"'                 { string newline (Buffer.create 42) lexbuf }
+  | '|'                 { quoted_symbol newline (Buffer.create 42) lexbuf }
   | keyword as s        { KEYWORD s }
   | simple_symbol as s                  { symbol newline lexbuf s}
-  | '|' (quoted_symbol_char* as s) '|'  { quoted_symbol newline lexbuf s }
-  | _                                   { raise Error }
+  | _                                   { raise (Error { context = None }) }
+
+and quoted_symbol newline b = parse
+  | '|'                         { SYMBOL (Buffer.contents b) }
+  | quoted_symbol_char as c
+    { if c = '\n' then newline lexbuf;
+      Buffer.add_char b c; quoted_symbol newline b lexbuf }
+  | _                           { raise (Error { context = Some "quoted_symbol" }) }
 
 and string newline b = parse
   | '"' '"'             { Buffer.add_char b '"'; string newline b lexbuf }
@@ -205,7 +202,7 @@ and string newline b = parse
   | (printable_char | white_space_char) as c
     { if c = '\n' then newline lexbuf;
       Buffer.add_char b c; string newline b lexbuf }
-  | _                   { raise Error }
+  | _                   { raise (Error { context = Some "string" }) }
 
 (* these are there to simplify the task of printers, by allowing to
    check strings against some lexical categories *)

--- a/src/languages/smtlib2/v2.7/response/lexer.mll
+++ b/src/languages/smtlib2/v2.7/response/lexer.mll
@@ -4,7 +4,7 @@
 (** {1 Smtlib Lexer} *)
 
 {
-  exception Error
+  exception Error of { context : string option; }
 
   module T = Dolmen_std.Tok
   module M = Map.Make(String)
@@ -95,15 +95,6 @@
     try M.find s reserved_words
     with Not_found -> SYMBOL s
 
-  let quoted_symbol newline lexbuf s =
-    (* register the newlines in quoted symbols to maintain correct locations.*)
-    for i = 0 to (String.length s - 1) do
-      match s.[i] with
-      | '\n' -> newline lexbuf
-      | _ -> ()
-    done;
-    (* Quoted symbols allow to use reserved words as symbols *)
-    SYMBOL s
 }
 
 let white_space_char = ['\t' '\n' '\r' ' ']
@@ -147,10 +138,16 @@ rule token newline = parse
   | hexadecimal as s    { HEX s }
   | binary as s         { BIN s }
   | '"'                 { string newline (Buffer.create 42) lexbuf }
+  | '|'                 { quoted_symbol newline (Buffer.create 42) lexbuf }
   | keyword as s        { KEYWORD s }
-  | simple_symbol as s                  { symbol newline lexbuf s }
-  | '|' (quoted_symbol_char* as s) '|'  { quoted_symbol newline lexbuf s }
-  | _                                   { raise Error }
+  | simple_symbol as s  { symbol newline lexbuf s }
+  | _                   { raise (Error { context = None; }) }
+
+and quoted_symbol newline b = parse
+  | '|'                         { SYMBOL (Buffer.contents b) }
+  | quoted_symbol_char as c     { if c = '\n' then newline lexbuf;
+                                  Buffer.add_char b c; quoted_symbol newline b lexbuf }
+  | _                           { raise (Error { context = Some "quoted_symbol" }) }
 
 and string newline b = parse
   | '"' '"'             { Buffer.add_char b '"'; string newline b lexbuf }
@@ -158,5 +155,5 @@ and string newline b = parse
   | (printable_char | white_space_char) as c
     { if c = '\n' then newline lexbuf;
       Buffer.add_char b c; string newline b lexbuf }
-  | _                   { raise Error }
+  | _                   { raise (Error { context = Some "string" }) }
 

--- a/src/languages/smtlib2/v2.7/script/lexer.mll
+++ b/src/languages/smtlib2/v2.7/script/lexer.mll
@@ -4,7 +4,7 @@
 (** {1 Smtlib Lexer} *)
 
 {
-  exception Error
+  exception Error of { context : string option; }
 
   module T = Dolmen_std.Tok
   module M = Map.Make(String)
@@ -144,16 +144,6 @@
     try M.find s reserved_words
     with Not_found -> SYMBOL s
 
-  let quoted_symbol newline lexbuf s =
-    (* register the newlines in quoted symbols to maintain correct locations.*)
-    for i = 0 to (String.length s - 1) do
-      match s.[i] with
-      | '\n' -> newline lexbuf
-      | _ -> ()
-    done;
-    (* Quoted symbols allow to use reserved words as symbols *)
-    SYMBOL s
-
 }
 
 let white_space_char = ['\t' '\n' '\r' ' ']
@@ -197,10 +187,16 @@ rule token newline = parse
   | hexadecimal as s    { HEX s }
   | binary as s         { BIN s }
   | '"'                 { string newline (Buffer.create 42) lexbuf }
+  | '|'                 { quoted_symbol newline (Buffer.create 42) lexbuf }
   | keyword as s        { KEYWORD s }
-  | simple_symbol as s                  { symbol newline lexbuf s}
-  | '|' (quoted_symbol_char* as s) '|'  { quoted_symbol newline lexbuf s }
-  | _                                   { raise Error }
+  | simple_symbol as s  { symbol newline lexbuf s }
+  | _                   { raise (Error { context = None; }) }
+
+and quoted_symbol newline b = parse
+  | '|'                         { SYMBOL (Buffer.contents b) }
+  | quoted_symbol_char as c     { if c = '\n' then newline lexbuf;
+                                  Buffer.add_char b c; quoted_symbol newline b lexbuf }
+  | _                           { raise (Error { context = Some "quoted_symbol" }) }
 
 and string newline b = parse
   | '"' '"'             { Buffer.add_char b '"'; string newline b lexbuf }
@@ -208,7 +204,7 @@ and string newline b = parse
   | (printable_char | white_space_char) as c
     { if c = '\n' then newline lexbuf;
       Buffer.add_char b c; string newline b lexbuf }
-  | _                   { raise Error }
+  | _                   { raise (Error { context = Some "string" }) }
 
 (* these are there to simplify the task of printers, by allowing to
    check strings against some lexical categories *)

--- a/src/languages/tptp/v6.3.0/lexer.mll
+++ b/src/languages/tptp/v6.3.0/lexer.mll
@@ -27,7 +27,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 (** {1 TPTP Lexer} *)
 
 {
-  exception Error
+  exception Error of { context : string option; }
 
   open Tokens
 
@@ -240,5 +240,5 @@ rule token newline = parse
   | rational            { RATIONAL(Lexing.lexeme lexbuf) }
   | real                { REAL(Lexing.lexeme lexbuf) }
 
-  | _ { raise Error }
+  | _ { raise (Error { context = None }) }
 

--- a/src/languages/zf/lexer.mll
+++ b/src/languages/zf/lexer.mll
@@ -4,7 +4,7 @@
 (** {1 Lexer for Zipperposition Formulas} *)
 
 {
-  exception Error
+  exception Error of { context : string option; }
 
   module T = Dolmen_std.Tok
 
@@ -171,7 +171,7 @@ rule token newline = parse
   | upper_word { UPPER_WORD(Lexing.lexeme lexbuf) }
   | integer { INTEGER(Lexing.lexeme lexbuf) }
   | '"' { quoted newline (Buffer.create 42) lexbuf }
-  | _ { raise Error }
+  | _ { raise (Error { context = None }) }
 
 (* we unquote during lexing rather then during the parsing *)
 and quoted newline b = parse

--- a/src/loop/parser.ml
+++ b/src/loop/parser.ml
@@ -42,9 +42,15 @@ let input_lang_changed =
 
 let lexing_error =
   Report.Error.mk ~code:Code.parsing ~mnemonic:"lexing-error"
-    ~message:(fun fmt lex ->
-        Format.fprintf fmt
-          "Lexing error: invalid character '%s'" lex)
+    ~message:(fun fmt (context, lex) ->
+        match context with
+        | None ->
+          Format.fprintf fmt
+            "Lexing error: invalid character '%s'" lex
+        | Some ctx ->
+          Format.fprintf fmt
+            "Lexing error: invalid character '%s' in a %s" lex ctx
+      )
     ~name:"Lexing error" ()
 
 let parsing_error =
@@ -183,8 +189,8 @@ module Make(State : State.S) = struct
           Report.Error.uncaught_exn (exn, bt)
       in
       st, None
-    | exception Dolmen.Std.Loc.Lexing_error (loc, lex) ->
-      let st = State.error st ~file ~loc:{ file = file.loc; loc; } lexing_error lex in
+    | exception Dolmen.Std.Loc.Lexing_error (loc, context, lex) ->
+      let st = State.error st ~file ~loc:{ file = file.loc; loc; } lexing_error (context, lex) in
       st, None
     | exception Dolmen.Std.Loc.Syntax_error (loc, perr) ->
       let syntax_error_ref = State.get_or ~default:false syntax_error_ref st in

--- a/src/loop/parser.mli
+++ b/src/loop/parser.mli
@@ -9,7 +9,7 @@ val extension_not_found : string Report.error
 val file_not_found : (string * string) Report.error
 (** Error for a missing file *)
 
-val lexing_error : string Report.error
+val lexing_error : (string option * string) Report.error
 (** Lexing errors *)
 
 val parsing_error : (bool *

--- a/src/standard/loc.ml
+++ b/src/standard/loc.ml
@@ -59,7 +59,7 @@ type loc = {
 (* ************************************************************************* *)
 
 exception Uncaught of t * exn * Printexc.raw_backtrace
-exception Lexing_error of t * string
+exception Lexing_error of t * string option * string
 exception Syntax_error of t * [
     | `Regular of Msg.t
     | `Advanced of string * Msg.t * Msg.t * Msg.t

--- a/src/standard/transformer.ml
+++ b/src/standard/transformer.ml
@@ -109,12 +109,12 @@ module Make
           let () = sync lexbuf in
           let () = k_exn () in
           raise e
-        | exception Lexer.Error ->
+        | exception Lexer.Error { context } ->
           let pos = Loc.of_lexbuf lexbuf in
           let err = Lexing.lexeme lexbuf in
           let () = sync lexbuf in
           let () = k_exn () in
-          raise (Loc.Lexing_error (pos, err))
+          raise (Loc.Lexing_error (pos, context, err))
         | exception Parser.Error state ->
           let pos = Loc.of_lexbuf lexbuf in
           let msg = error_message !last_token state in

--- a/tests/parsing/smtlib/poly/errors/dune
+++ b/tests/parsing/smtlib/poly/errors/dune
@@ -7361,4 +7361,36 @@
   (action (diff xxx_define_funs_res_mismatched_lists.expected xxx_define_funs_res_mismatched_lists.full)))
 
 
+; Test for xxx_lexing_invalid_char_in_quoted_symbol.smt2
+; Incremental test
+
+(rule
+   (target  xxx_lexing_invalid_char_in_quoted_symbol.incremental)
+   (deps    (:input xxx_lexing_invalid_char_in_quoted_symbol.smt2))
+   (package dolmen_bin)
+   (action (chdir %{workspace_root}
+            (with-outputs-to %{target}
+             (with-accepted-exit-codes (or 0 (not 0))
+              (run dolmen --mode=incremental --color=never %{input} %{read-lines:flags.dune}))))))
+(rule
+  (alias runtest)
+  (package dolmen_bin)
+  (action (diff xxx_lexing_invalid_char_in_quoted_symbol.expected xxx_lexing_invalid_char_in_quoted_symbol.incremental)))
+
+; Full mode test
+
+(rule
+   (target  xxx_lexing_invalid_char_in_quoted_symbol.full)
+   (deps    (:input xxx_lexing_invalid_char_in_quoted_symbol.smt2))
+   (package dolmen_bin)
+   (action (chdir %{workspace_root}
+            (with-outputs-to %{target}
+             (with-accepted-exit-codes (or 0 (not 0))
+              (run dolmen --mode=full --color=never %{input} %{read-lines:flags.dune}))))))
+(rule
+  (alias runtest)
+  (package dolmen_bin)
+  (action (diff xxx_lexing_invalid_char_in_quoted_symbol.expected xxx_lexing_invalid_char_in_quoted_symbol.full)))
+
+
 ; Auto-generated part end

--- a/tests/parsing/smtlib/poly/errors/xxx_lexing_invalid_char_in_quoted_symbol.expected
+++ b/tests/parsing/smtlib/poly/errors/xxx_lexing_invalid_char_in_quoted_symbol.expected
@@ -1,0 +1,4 @@
+File "tests/parsing/smtlib/poly/errors/xxx_lexing_invalid_char_in_quoted_symbol.smt2", line 1, character 29-30:
+1 | (set-info :source |blablabla \ |)
+                                 ^
+Error Lexing error: invalid character '\' in a quoted_symbol

--- a/tests/parsing/smtlib/poly/errors/xxx_lexing_invalid_char_in_quoted_symbol.smt2
+++ b/tests/parsing/smtlib/poly/errors/xxx_lexing_invalid_char_in_quoted_symbol.smt2
@@ -1,0 +1,1 @@
+(set-info :source |blablabla \ |)

--- a/tests/parsing/smtlib/v2.6/errors/dune
+++ b/tests/parsing/smtlib/v2.6/errors/dune
@@ -6593,4 +6593,36 @@
   (action (diff xxx_lexing_invalid_char.expected xxx_lexing_invalid_char.full)))
 
 
+; Test for xxx_lexing_invalid_char_in_quoted_symbol.smt2
+; Incremental test
+
+(rule
+   (target  xxx_lexing_invalid_char_in_quoted_symbol.incremental)
+   (deps    (:input xxx_lexing_invalid_char_in_quoted_symbol.smt2))
+   (package dolmen_bin)
+   (action (chdir %{workspace_root}
+            (with-outputs-to %{target}
+             (with-accepted-exit-codes (or 0 (not 0))
+              (run dolmen --mode=incremental --color=never %{input} %{read-lines:flags.dune}))))))
+(rule
+  (alias runtest)
+  (package dolmen_bin)
+  (action (diff xxx_lexing_invalid_char_in_quoted_symbol.expected xxx_lexing_invalid_char_in_quoted_symbol.incremental)))
+
+; Full mode test
+
+(rule
+   (target  xxx_lexing_invalid_char_in_quoted_symbol.full)
+   (deps    (:input xxx_lexing_invalid_char_in_quoted_symbol.smt2))
+   (package dolmen_bin)
+   (action (chdir %{workspace_root}
+            (with-outputs-to %{target}
+             (with-accepted-exit-codes (or 0 (not 0))
+              (run dolmen --mode=full --color=never %{input} %{read-lines:flags.dune}))))))
+(rule
+  (alias runtest)
+  (package dolmen_bin)
+  (action (diff xxx_lexing_invalid_char_in_quoted_symbol.expected xxx_lexing_invalid_char_in_quoted_symbol.full)))
+
+
 ; Auto-generated part end

--- a/tests/parsing/smtlib/v2.6/errors/xxx_lexing_invalid_char_in_quoted_symbol.expected
+++ b/tests/parsing/smtlib/v2.6/errors/xxx_lexing_invalid_char_in_quoted_symbol.expected
@@ -1,0 +1,4 @@
+File "tests/parsing/smtlib/v2.6/errors/xxx_lexing_invalid_char_in_quoted_symbol.smt2", line 1, character 29-30:
+1 | (set-info :source |blablabla \ |)
+                                 ^
+Error Lexing error: invalid character '\' in a quoted_symbol

--- a/tests/parsing/smtlib/v2.6/errors/xxx_lexing_invalid_char_in_quoted_symbol.smt2
+++ b/tests/parsing/smtlib/v2.6/errors/xxx_lexing_invalid_char_in_quoted_symbol.smt2
@@ -1,0 +1,1 @@
+(set-info :source |blablabla \ |)

--- a/tests/parsing/smtlib/v2.7/errors/dune
+++ b/tests/parsing/smtlib/v2.7/errors/dune
@@ -6561,4 +6561,36 @@
   (action (diff xxx_lexing_invalid_char.expected xxx_lexing_invalid_char.full)))
 
 
+; Test for xxx_lexing_invalid_char_in_quoted_symbol.smt2
+; Incremental test
+
+(rule
+   (target  xxx_lexing_invalid_char_in_quoted_symbol.incremental)
+   (deps    (:input xxx_lexing_invalid_char_in_quoted_symbol.smt2))
+   (package dolmen_bin)
+   (action (chdir %{workspace_root}
+            (with-outputs-to %{target}
+             (with-accepted-exit-codes (or 0 (not 0))
+              (run dolmen --mode=incremental --color=never %{input} %{read-lines:flags.dune}))))))
+(rule
+  (alias runtest)
+  (package dolmen_bin)
+  (action (diff xxx_lexing_invalid_char_in_quoted_symbol.expected xxx_lexing_invalid_char_in_quoted_symbol.incremental)))
+
+; Full mode test
+
+(rule
+   (target  xxx_lexing_invalid_char_in_quoted_symbol.full)
+   (deps    (:input xxx_lexing_invalid_char_in_quoted_symbol.smt2))
+   (package dolmen_bin)
+   (action (chdir %{workspace_root}
+            (with-outputs-to %{target}
+             (with-accepted-exit-codes (or 0 (not 0))
+              (run dolmen --mode=full --color=never %{input} %{read-lines:flags.dune}))))))
+(rule
+  (alias runtest)
+  (package dolmen_bin)
+  (action (diff xxx_lexing_invalid_char_in_quoted_symbol.expected xxx_lexing_invalid_char_in_quoted_symbol.full)))
+
+
 ; Auto-generated part end

--- a/tests/parsing/smtlib/v2.7/errors/xxx_lexing_invalid_char_in_quoted_symbol.expected
+++ b/tests/parsing/smtlib/v2.7/errors/xxx_lexing_invalid_char_in_quoted_symbol.expected
@@ -1,0 +1,4 @@
+File "tests/parsing/smtlib/v2.7/errors/xxx_lexing_invalid_char_in_quoted_symbol.smt2", line 1, character 29-30:
+1 | (set-info :source |blablabla \ |)
+                                 ^
+Error Lexing error: invalid character '\' in a quoted_symbol

--- a/tests/parsing/smtlib/v2.7/errors/xxx_lexing_invalid_char_in_quoted_symbol.smt2
+++ b/tests/parsing/smtlib/v2.7/errors/xxx_lexing_invalid_char_in_quoted_symbol.smt2
@@ -1,0 +1,1 @@
+(set-info :source |blablabla \ |)

--- a/tests/qcheck/print.ml
+++ b/tests/qcheck/print.ml
@@ -31,7 +31,7 @@ let identifier
          let _ = Lazy.force l in
          true
        with
-       | Dolmen.Std.Loc.Lexing_error (_loc, lex) ->
+       | Dolmen.Std.Loc.Lexing_error (_loc, _context, lex) ->
          QCheck2.Test.fail_reportf "lexing: invalid char: '%s'" lex
        | Dolmen.Std.Loc.Syntax_error (_loc, perr) ->
          begin match perr with


### PR DESCRIPTION
When lexing of a quoted symbol in smt-lib failed, due to the structure of the lexer, the error was reported as an invalid cahracter on the pipe that started the quoted symbol, which was quite misleading (although technically correct). This is fixed in two ways:
- change the parser so that the error can be raised on the invalid char inside of ther quoted symbol (possible in smt-lib because a pipe can only be the start of a quoted symbol)
- the lexing error raised by lexer now carry the context of where the lexer was, allowing to specify e.g. that a character is invalid inside of a comment/string/quoted symbol

See e.g. the discussion in https://github.com/SMT-LIB/benchmark-submission/pull/12